### PR TITLE
Init solver with Levenberg-Marquardt optimizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,23 +947,11 @@ checksum = "26aecdf64b707efd1310e3544d709c5c0ac61c13756046aaaba41be5c4f66a3b"
 dependencies = [
  "approx",
  "matrixmultiply",
- "nalgebra-macros",
  "num-complex",
  "num-rational",
  "num-traits",
  "simba",
  "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1061,6 +1049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +440,7 @@ version = "0.1.0"
 dependencies = [
  "kurbo",
  "libm",
+ "nalgebra",
 ]
 
 [[package]]
@@ -858,6 +868,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +940,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26aecdf64b707efd1310e3544d709c5c0ac61c13756046aaaba41be5c4f66a3b"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,6 +1013,45 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1428,6 +1514,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "read-fonts"
 version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,6 +1636,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,6 +1712,19 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simba"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a386a501cd104797982c15ae17aafe8b9261315b5d07e3ec803f2ea26be0fa"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -1942,6 +2056,12 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"
@@ -2349,6 +2469,16 @@ dependencies = [
  "js-sys",
  "log",
  "web-sys",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/fiksi/Cargo.toml
+++ b/fiksi/Cargo.toml
@@ -17,14 +17,14 @@ targets = []
 
 [features]
 default = ["std"]
-std = ["kurbo/std"]
-libm = ["dep:libm", "kurbo/libm"]
+std = ["kurbo/std", "nalgebra/std"]
+libm = ["dep:libm", "kurbo/libm", "nalgebra/libm"]
 
 [dependencies]
 kurbo = { version = "0.11.2", default-features = false }
 
 # Temporarily included
-nalgebra = { version = "0.33.2" }
+nalgebra = { version = "0.33.2", default-features = false, features = ["alloc"] }
 
 [dependencies.libm]
 version = "0.2.15"

--- a/fiksi/Cargo.toml
+++ b/fiksi/Cargo.toml
@@ -23,6 +23,9 @@ libm = ["dep:libm", "kurbo/libm"]
 [dependencies]
 kurbo = { version = "0.11.2", default-features = false }
 
+# Temporarily included
+nalgebra = { version = "0.33.2" }
+
 [dependencies.libm]
 version = "0.2.15"
 optional = true

--- a/fiksi/README.md
+++ b/fiksi/README.md
@@ -33,6 +33,36 @@ Fiksi is a geometric and parametric constraint solver.
 
 At least one of `std` and `libm` is required; `std` overrides `libm`.
 
+# Example
+
+```rust
+let mut gcs = fiksi::System::new();
+let element_set = gcs.add_element_set();
+let constraint_set = gcs.add_constraint_set();
+
+// Add three points, and constrain them into a triangle, such that
+// - one corner has an angle of 10 degrees;
+// - one corner has an angle of 60 degrees; and
+// - the side between those corners is of length 5.
+let p1 = gcs.add_element(&[&element_set], fiksi::elements::Point { x: 1., y: 0. });
+let p2 = gcs.add_element(&[&element_set], fiksi::elements::Point { x: 0.8, y: 1. });
+let p3 = gcs.add_element(&[&element_set], fiksi::elements::Point { x: 1.1, y: 2. });
+
+gcs.add_constraint(
+    &[&constraint_set],
+    fiksi::constraints::PointPointDistance::new(&p2, &p3, 5.),
+);
+gcs.add_constraint(
+    &[&constraint_set],
+    fiksi::constraints::PointPointPointAngle::new(&p1, &p2, &p3, 10f64.to_radians()),
+);
+gcs.add_constraint(
+    &[&constraint_set],
+    fiksi::constraints::PointPointPointAngle::new(&p2, &p3, &p1, 60f64.to_radians()),
+);
+gcs.solve(&element_set, &constraint_set);
+```
+
 <!-- cargo-rdme end -->
 
 ## Minimum supported Rust Version (MSRV)

--- a/fiksi/src/constraints/mod.rs
+++ b/fiksi/src/constraints/mod.rs
@@ -1,0 +1,345 @@
+// Copyright 2025 the Fiksi Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Constraints between geometric elements.
+
+use crate::Edge;
+use crate::Vertex;
+use crate::elements;
+use crate::{ElementHandle, ElementId};
+
+pub(crate) mod constraint {
+    use core::marker::PhantomData;
+
+    /// A handle to a constraint within a [`System`](crate::System).
+    #[derive(Debug)]
+    pub struct ConstraintHandle<T> {
+        /// The ID of the system the constraint belongs to.
+        system_id: u32,
+        /// The ID of the constraint within the system.
+        id: u32,
+        _t: PhantomData<T>,
+    }
+
+    impl<T> ConstraintHandle<T> {
+        pub(crate) fn from_ids(system_id: u32, id: u32) -> Self {
+            Self {
+                system_id,
+                id,
+                _t: PhantomData::default(),
+            }
+        }
+
+        pub(crate) fn drop_system_id(&self) -> ConstraintId {
+            ConstraintId { id: self.id }
+        }
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    pub(crate) struct ConstraintId {
+        /// The ID of the constraint within the system.
+        pub(crate) id: u32,
+    }
+}
+
+/// Constrain two points to have a given straight-line distance between each other.
+pub struct PointPointDistance {
+    point1: ElementId,
+    point2: ElementId,
+
+    /// Euclidean distance.
+    distance: f64,
+}
+
+impl sealed::ConstraintInner for PointPointDistance {
+    fn as_edge(&self, vertices: &[Vertex]) -> Edge {
+        let &Vertex::Point { idx: point1_idx } = &vertices[self.point1.id as usize] else {
+            unreachable!()
+        };
+        let &Vertex::Point { idx: point2_idx } = &vertices[self.point2.id as usize] else {
+            unreachable!()
+        };
+        Edge::PointPointDistance {
+            point1_idx,
+            point2_idx,
+            distance: self.distance,
+        }
+    }
+}
+
+impl PointPointDistance {
+    /// Construct a constraint between two points to have a given straight-line distance between each other.
+    ///
+    /// `distance` is the Euclidean distance between `point1` and `point2`.
+    pub fn new(
+        point1: &ElementHandle<elements::Point>,
+        point2: &ElementHandle<elements::Point>,
+        distance: f64,
+    ) -> Self {
+        Self {
+            point1: point1.drop_system_id(),
+            point2: point2.drop_system_id(),
+            distance,
+        }
+    }
+}
+
+/// A representation of a [`PointPointDistance`] constraint within a [`crate::System`], allowing
+/// evaluation.
+///
+/// TODO: can this be merged with [`PointPointDistance`]?
+pub(crate) struct PointPointDistance_ {
+    pub point1_idx: u32,
+    pub point2_idx: u32,
+
+    /// Euclidean distance.
+    pub distance: f64,
+}
+
+impl PointPointDistance_ {
+    pub(crate) fn compute_residual_and_partial_derivatives(
+        &self,
+        index_map: &alloc::collections::BTreeMap<u32, u32>,
+        variables: &[f64],
+        residual: &mut f64,
+        first_derivative: &mut [f64],
+    ) {
+        let point1 = kurbo::Point {
+            x: variables[self.point1_idx as usize],
+            y: variables[self.point1_idx as usize + 1],
+        };
+        let point2 = kurbo::Point {
+            x: variables[self.point2_idx as usize],
+            y: variables[self.point2_idx as usize + 1],
+        };
+
+        let distance = ((point1.x - point2.x).powi(2) + (point1.y - point2.y).powi(2)).sqrt();
+        *residual += distance - self.distance;
+
+        let distance_recip = 1. / distance;
+        let derivative = [
+            (point1.x - point2.x) * distance_recip,
+            (point1.y - point2.y) * distance_recip,
+            -(point1.x - point2.x) * distance_recip,
+            -(point1.y - point2.y) * distance_recip,
+        ];
+
+        if let Some(idx) = index_map.get(&self.point1_idx) {
+            first_derivative[*idx as usize] += derivative[0];
+        }
+        if let Some(idx) = index_map.get(&(self.point1_idx + 1)) {
+            first_derivative[*idx as usize] += derivative[1];
+        }
+        if let Some(idx) = index_map.get(&self.point2_idx) {
+            first_derivative[*idx as usize] += derivative[2];
+        }
+        if let Some(idx) = index_map.get(&(self.point2_idx + 1)) {
+            first_derivative[*idx as usize] += derivative[3];
+        }
+    }
+}
+
+/// Constrain three points to describe a given angle.
+pub struct PointPointPointAngle {
+    point1: ElementId,
+    point2: ElementId,
+    point3: ElementId,
+
+    /// Angle in radians.
+    angle: f64,
+}
+
+impl sealed::ConstraintInner for PointPointPointAngle {
+    fn as_edge(&self, vertices: &[Vertex]) -> Edge {
+        let &Vertex::Point { idx: point1_idx } = &vertices[self.point1.id as usize] else {
+            unreachable!()
+        };
+        let &Vertex::Point { idx: point2_idx } = &vertices[self.point2.id as usize] else {
+            unreachable!()
+        };
+        let &Vertex::Point { idx: point3_idx } = &vertices[self.point3.id as usize] else {
+            unreachable!()
+        };
+        Edge::PointPointPointAngle {
+            point1_idx,
+            point2_idx,
+            point3_idx,
+            angle: self.angle,
+        }
+    }
+}
+
+impl PointPointPointAngle {
+    /// Construct a constraint between three points to describe ag iven angle.
+    ///
+    /// `angle` is the angle in radians the points should describe.
+    pub fn new(
+        point1: &ElementHandle<elements::Point>,
+        point2: &ElementHandle<elements::Point>,
+        point3: &ElementHandle<elements::Point>,
+        angle: f64,
+    ) -> Self {
+        Self {
+            point1: point1.drop_system_id(),
+            point2: point2.drop_system_id(),
+            point3: point3.drop_system_id(),
+            angle,
+        }
+    }
+}
+
+/// A representation of a [`PointPointPointAngle`] constraint within a [`crate::System`], allowing
+/// evaluation.
+///
+/// TODO: can this be merged with [`PointPointPointAngle`]?
+pub(crate) struct PointPointPointAngle_ {
+    pub point1_idx: u32,
+    pub point2_idx: u32,
+    pub point3_idx: u32,
+
+    /// Angle in radians.
+    pub angle: f64,
+}
+
+impl PointPointPointAngle_ {
+    pub(crate) fn compute_residual_and_partial_derivatives(
+        &self,
+        index_map: &alloc::collections::BTreeMap<u32, u32>,
+        variables: &[f64],
+        residual: &mut f64,
+        first_derivative: &mut [f64],
+    ) {
+        let point1 = kurbo::Point {
+            x: variables[self.point1_idx as usize],
+            y: variables[self.point1_idx as usize + 1],
+        };
+        let point2 = kurbo::Point {
+            x: variables[self.point2_idx as usize],
+            y: variables[self.point2_idx as usize + 1],
+        };
+        let point3 = kurbo::Point {
+            x: variables[self.point3_idx as usize],
+            y: variables[self.point3_idx as usize + 1],
+        };
+
+        let u = point1 - point2;
+        let v = point3 - point2;
+
+        let angle = v.atan2() - u.atan2();
+        let angle = if angle > core::f64::consts::PI {
+            angle - 2.0 * core::f64::consts::PI
+        } else if angle < -core::f64::consts::PI {
+            angle + 2.0 * core::f64::consts::PI
+        } else {
+            angle
+        };
+
+        *residual += angle - self.angle;
+
+        let u_squared_recip = u.length_squared().recip();
+        let v_squared_recip = v.length_squared().recip();
+
+        let dangle_dpoint1x = u.y * u_squared_recip;
+        let dangle_dpoint1y = -u.x * u_squared_recip;
+        let dangle_dpoint3x = -v.y * v_squared_recip;
+        let dangle_dpoint3y = v.x * v_squared_recip;
+
+        let dangle_dpoint2x = -dangle_dpoint1x - dangle_dpoint3x;
+        let dangle_dpoint2y = -dangle_dpoint1y - dangle_dpoint3y;
+
+        let derivative = [
+            dangle_dpoint1x,
+            dangle_dpoint1y,
+            dangle_dpoint2x,
+            dangle_dpoint2y,
+            dangle_dpoint3x,
+            dangle_dpoint3y,
+        ];
+
+        if let Some(idx) = index_map.get(&self.point1_idx) {
+            first_derivative[*idx as usize] += derivative[0];
+        }
+        if let Some(idx) = index_map.get(&(self.point1_idx + 1)) {
+            first_derivative[*idx as usize] += derivative[1];
+        }
+        if let Some(idx) = index_map.get(&self.point2_idx) {
+            first_derivative[*idx as usize] += derivative[2];
+        }
+        if let Some(idx) = index_map.get(&(self.point2_idx + 1)) {
+            first_derivative[*idx as usize] += derivative[3];
+        }
+        if let Some(idx) = index_map.get(&(self.point3_idx)) {
+            first_derivative[*idx as usize] += derivative[4];
+        }
+        if let Some(idx) = index_map.get(&(self.point3_idx + 1)) {
+            first_derivative[*idx as usize] += derivative[5];
+        }
+    }
+}
+
+/// Constrain two lines to describe a given angle.
+///
+/// TODO: actually implement this, or require using [`PointPointPointAngle`]?
+pub struct LineLineAngle {
+    line1: ElementHandle<elements::Line>,
+    line2: ElementHandle<elements::Line>,
+
+    /// Angle in radians.
+    angle: f64,
+}
+
+impl sealed::ConstraintInner for LineLineAngle {
+    fn as_edge(&self, vertices: &[Vertex]) -> Edge {
+        let &Vertex::Line {
+            point1_idx,
+            point2_idx,
+        } = &vertices[self.line1.id as usize]
+        else {
+            unreachable!()
+        };
+        let &Vertex::Line {
+            point1_idx: point3_idx,
+            point2_idx: point4_idx,
+        } = &vertices[self.line2.id as usize]
+        else {
+            unreachable!()
+        };
+        Edge::LineLineAngle {
+            point1_idx,
+            point2_idx,
+            point3_idx,
+            point4_idx,
+            angle: self.angle,
+        }
+    }
+}
+
+/// A representation of a [`LineLineAngle`] constraint within a [`crate::System`], allowing
+/// evaluation.
+///
+/// TODO: implement
+/// TODO: can this be merged with [`LineLineAngle`]?
+pub(crate) struct LineLineAngle_ {
+    pub point1_idx: u32,
+    pub point2_idx: u32,
+    pub point3_idx: u32,
+    pub point4_idx: u32,
+
+    /// Angle in radians.
+    pub angle: f64,
+}
+
+pub(crate) mod sealed {
+    pub(crate) trait ConstraintInner {
+        fn as_edge(&self, vertices: &[crate::Vertex]) -> crate::Edge;
+    }
+}
+
+/// A constraint between geometric [elements](crate::Element).
+///
+/// These can be added to a [`System`](crate::System).
+#[expect(private_bounds, reason = "Sealed inner trait")]
+pub trait Constraint: sealed::ConstraintInner {}
+impl Constraint for PointPointDistance {}
+impl Constraint for PointPointPointAngle {}
+impl Constraint for LineLineAngle {}

--- a/fiksi/src/constraints/mod.rs
+++ b/fiksi/src/constraints/mod.rs
@@ -3,7 +3,7 @@
 
 //! Constraints between geometric elements.
 
-#[cfg(feature = "libm")]
+#[cfg(not(feature = "std"))]
 use crate::floatfuncs::FloatFuncs;
 
 use crate::Edge;

--- a/fiksi/src/constraints/mod.rs
+++ b/fiksi/src/constraints/mod.rs
@@ -15,7 +15,7 @@ trait FloatExt {
     /// Returns the square of `self`.
     ///
     /// Using `std`, you'd be able to do this using `self.powi(2)`, and have this be compiled to a
-    /// single multiply op. However, when compiling using `libm`, there is no `powi` and libm's
+    /// `self * self`. However, when compiling using `libm`, there is no `powi` and libm's
     /// `self.powf(2.)` doesn't compile away.
     fn square(self) -> Self;
 }
@@ -45,7 +45,7 @@ pub(crate) mod constraint {
             Self {
                 system_id,
                 id,
-                _t: PhantomData::default(),
+                _t: PhantomData,
             }
         }
 

--- a/fiksi/src/constraints/mod.rs
+++ b/fiksi/src/constraints/mod.rs
@@ -3,10 +3,29 @@
 
 //! Constraints between geometric elements.
 
+#[cfg(feature = "libm")]
+use crate::floatfuncs::FloatFuncs;
+
 use crate::Edge;
 use crate::Vertex;
 use crate::elements;
 use crate::{ElementHandle, ElementId};
+
+trait FloatExt {
+    /// Returns the square of `self`.
+    ///
+    /// Using `std`, you'd be able to do this using `self.powi(2)`, and have this be compiled to a
+    /// single multiply op. However, when compiling using `libm`, there is no `powi` and libm's
+    /// `self.powf(2.)` doesn't compile away.
+    fn square(self) -> Self;
+}
+
+impl FloatExt for f64 {
+    #[inline(always)]
+    fn square(self) -> Self {
+        self * self
+    }
+}
 
 pub(crate) mod constraint {
     use core::marker::PhantomData;
@@ -113,7 +132,7 @@ impl PointPointDistance_ {
             y: variables[self.point2_idx as usize + 1],
         };
 
-        let distance = ((point1.x - point2.x).powi(2) + (point1.y - point2.y).powi(2)).sqrt();
+        let distance = ((point1.x - point2.x).square() + (point1.y - point2.y).square()).sqrt();
         *residual += distance - self.distance;
 
         let distance_recip = 1. / distance;

--- a/fiksi/src/elements/mod.rs
+++ b/fiksi/src/elements/mod.rs
@@ -1,0 +1,142 @@
+// Copyright 2025 the Fiksi Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Geometric elements like points and lines.
+
+use alloc::vec::Vec;
+
+pub(crate) mod element {
+    use core::marker::PhantomData;
+
+    /// A handle to an element within a [`System`](crate::System).
+    #[derive(Debug)]
+    pub struct ElementHandle<T> {
+        /// The ID of the system the element belongs to.
+        pub(crate) system_id: u32,
+        /// The ID of the element within the system.
+        pub(crate) id: u32,
+        _t: PhantomData<T>,
+    }
+
+    impl<T> ElementHandle<T> {
+        pub(crate) fn from_ids(system_id: u32, id: u32) -> Self {
+            Self {
+                system_id,
+                id,
+                _t: PhantomData::default(),
+            }
+        }
+
+        pub(crate) fn drop_system_id(&self) -> ElementId {
+            ElementId { id: self.id }
+        }
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    pub(crate) struct ElementId {
+        /// The ID of the element within the system.
+        pub(crate) id: u32,
+    }
+
+    impl ElementId {
+        pub(crate) fn from_id(id: u32) -> Self {
+            Self { id }
+        }
+    }
+}
+
+use element::ElementHandle;
+
+use crate::Vertex;
+
+/// A point given by a 2D coordinate.
+#[derive(Debug)]
+pub struct Point {
+    /// The x-coordinate of the point.
+    pub x: f64,
+    /// The y-coordinate of the point.
+    pub y: f64,
+}
+
+impl sealed::ElementInner for Point {
+    fn add_into(&self, element_vertices: &mut Vec<Vertex>, variables: &mut Vec<f64>) {
+        element_vertices.push(Vertex::Point {
+            idx: variables
+                .len()
+                .try_into()
+                .expect("less than 2^32 variables"),
+        });
+        variables.extend(&[self.x, self.y]);
+    }
+
+    fn from_vertex(vertex: &Vertex, variables: &[f64]) -> Self {
+        if let &Vertex::Point { idx } = vertex {
+            Point {
+                x: variables[idx as usize],
+                y: variables[idx as usize + 1],
+            }
+        } else {
+            unreachable!()
+        }
+    }
+}
+
+/// A line defined by two endpoints.
+#[derive(Debug)]
+pub struct Line {
+    /// First point of the line.
+    pub point1: ElementHandle<Point>,
+    /// Second point of the line.
+    pub point2: ElementHandle<Point>,
+}
+
+impl sealed::ElementInner for Line {
+    fn add_into(&self, vertices: &mut Vec<Vertex>, _data: &mut Vec<f64>) {
+        let &Vertex::Point { idx: point1_idx } = &vertices[self.point1.id as usize] else {
+            unreachable!()
+        };
+        let &Vertex::Point { idx: point2_idx } = &vertices[self.point2.id as usize] else {
+            unreachable!()
+        };
+        vertices.push(Vertex::Line {
+            point1_idx,
+            point2_idx,
+        });
+    }
+
+    fn from_vertex(_vertex: &Vertex, _variables: &[f64]) -> Self {
+        unimplemented!()
+    }
+}
+
+/// A circle defined by a centerpoint and a radius.
+///
+/// TODO: use.
+#[derive(Debug)]
+pub struct Circle {
+    /// The center of the circle.
+    pub center: ElementHandle<Point>,
+
+    /// The radius of the circle.
+    pub radius: f64,
+}
+
+pub(crate) mod sealed {
+    use alloc::vec::Vec;
+
+    use crate::Vertex;
+
+    pub(crate) trait ElementInner {
+        fn add_into(&self, element_vertices: &mut Vec<Vertex>, variables: &mut Vec<f64>);
+        fn from_vertex(vertex: &Vertex, variables: &[f64]) -> Self;
+    }
+}
+
+/// A geometric element that can be [constrained](crate::Constraint).
+///
+/// These can be added to a [`System`](crate::System).
+#[expect(private_bounds, reason = "Sealed inner trait")]
+pub trait Element: sealed::ElementInner {}
+
+impl Element for Point {}
+impl Element for Line {}

--- a/fiksi/src/elements/mod.rs
+++ b/fiksi/src/elements/mod.rs
@@ -23,7 +23,7 @@ pub(crate) mod element {
             Self {
                 system_id,
                 id,
-                _t: PhantomData::default(),
+                _t: PhantomData,
             }
         }
 
@@ -71,7 +71,7 @@ impl sealed::ElementInner for Point {
 
     fn from_vertex(vertex: &Vertex, variables: &[f64]) -> Self {
         if let &Vertex::Point { idx } = vertex {
-            Point {
+            Self {
                 x: variables[idx as usize],
                 y: variables[idx as usize + 1],
             }

--- a/fiksi/src/lib.rs
+++ b/fiksi/src/lib.rs
@@ -11,6 +11,35 @@
 //!
 //! At least one of `std` and `libm` is required; `std` overrides `libm`.
 //!
+//! # Example
+//!
+//! ```rust
+//! let mut gcs = fiksi::System::new();
+//! let element_set = gcs.add_element_set();
+//! let constraint_set = gcs.add_constraint_set();
+//!
+//! // Add three points, and constrain them into a triangle, such that
+//! // - one corner has an angle of 10 degrees;
+//! // - one corner has an angle of 60 degrees; and
+//! // - the side between those corners is of length 5.
+//! let p1 = gcs.add_element(&[&element_set], fiksi::elements::Point { x: 1., y: 0. });
+//! let p2 = gcs.add_element(&[&element_set], fiksi::elements::Point { x: 0.8, y: 1. });
+//! let p3 = gcs.add_element(&[&element_set], fiksi::elements::Point { x: 1.1, y: 2. });
+//!
+//! gcs.add_constraint(
+//!     &[&constraint_set],
+//!     fiksi::constraints::PointPointDistance::new(&p2, &p3, 5.),
+//! );
+//! gcs.add_constraint(
+//!     &[&constraint_set],
+//!     fiksi::constraints::PointPointPointAngle::new(&p1, &p2, &p3, 10f64.to_radians()),
+//! );
+//! gcs.add_constraint(
+//!     &[&constraint_set],
+//!     fiksi::constraints::PointPointPointAngle::new(&p2, &p3, &p1, 60f64.to_radians()),
+//! );
+//! gcs.solve(&element_set, &constraint_set);
+//! ```
 #![cfg_attr(feature = "libm", doc = "[libm]: libm")]
 #![cfg_attr(not(feature = "libm"), doc = "[libm]: https://crates.io/crates/libm")]
 // LINEBENDER LINT SET - lib.rs - v3
@@ -24,6 +53,9 @@
 // END LINEBENDER LINT SET
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![no_std]
+// TODO: remove these two
+#![expect(dead_code)]
+#![expect(missing_debug_implementations)]
 
 #[cfg(all(not(feature = "std"), not(test)))]
 mod floatfuncs;
@@ -35,12 +67,199 @@ fn ensure_libm_dependency_used() -> f32 {
     libm::sqrtf(4_f32)
 }
 
+extern crate alloc;
+use alloc::{vec, vec::Vec};
+
 pub use kurbo;
 
-#[cfg(test)]
-mod tests {
-    // CI will fail unless cargo nextest can execute at least one test per workspace.
-    // Delete this dummy test once we have an actual real test.
-    #[test]
-    fn dummy_test_until_we_have_a_real_test() {}
+pub mod constraints;
+pub mod elements;
+mod solve;
+
+pub(crate) use constraints::constraint::ConstraintId;
+pub use constraints::{Constraint, constraint::ConstraintHandle};
+use elements::element::ElementId;
+pub use elements::{Element, element::ElementHandle};
+
+/// Vertices are the geometric elements of the constraint system.
+pub(crate) enum Vertex {
+    Point { idx: u32 },
+    Line { point1_idx: u32, point2_idx: u32 },
+}
+
+/// Edges are the constraints between geometric elements (i.e., edges between the vertices).
+pub(crate) enum Edge {
+    PointPointDistance {
+        point1_idx: u32,
+        point2_idx: u32,
+        distance: f64,
+    },
+    PointPointPointAngle {
+        point1_idx: u32,
+        point2_idx: u32,
+        point3_idx: u32,
+        angle: f64,
+    },
+    LineLineAngle {
+        point1_idx: u32,
+        point2_idx: u32,
+        point3_idx: u32,
+        point4_idx: u32,
+        angle: f64,
+    },
+}
+
+/// A handle to an element set.
+///
+/// See [`System::add_element_set`].
+pub struct ElementSetHandle {
+    /// The ID of the system the element set belongs to.
+    system_id: u32,
+    /// The ID of the element set within the system.
+    id: u32,
+}
+
+/// A handle to a constraint set.
+///
+/// See [`System::add_constraint_set`].
+pub struct ConstraintSetHandle {
+    /// The ID of the system the constraint set belongs to.
+    system_id: u32,
+    /// The ID of the constraint set within the system.
+    id: u32,
+}
+
+/// A geometric constraint system.
+///
+/// Build the system by [adding elements](System::add_element) and
+/// [constraints](System::add_constraint). Then solve (sub)systems using [`System::solve`].
+pub struct System {
+    id: u32,
+    variables: Vec<f64>,
+    element_sets: Vec<Vec<ElementId>>,
+    constraint_sets: Vec<Vec<ConstraintId>>,
+    element_vertices: Vec<Vertex>,
+    constraint_edges: Vec<Edge>,
+}
+
+impl System {
+    /// Construct an empty geometric constraint system.
+    pub fn new() -> Self {
+        static COUNTER: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+
+        System {
+            id,
+            variables: vec![],
+            element_sets: vec![],
+            constraint_sets: vec![],
+            element_vertices: vec![],
+            constraint_edges: vec![],
+        }
+    }
+
+    /// Add an element set to the geometric constraint system.
+    ///
+    /// Element sets are used to isolate distinct parts of constraint systems to be solved separately.
+    /// You always solve for exactly one element set at once.
+    ///
+    /// In simple cases, you may just create two groups: one group for fixed parameters, and the
+    /// other group for free variables.
+    pub fn add_element_set(&mut self) -> ElementSetHandle {
+        let id = self.element_sets.len();
+        self.element_sets.push(vec![]);
+
+        ElementSetHandle {
+            system_id: self.id,
+            id: id.try_into().expect("less than 2^32 element sets"),
+        }
+    }
+
+    /// Add a constraint set to the geometric constraint system.
+    pub fn add_constraint_set(&mut self) -> ConstraintSetHandle {
+        let id = self.constraint_sets.len();
+        self.constraint_sets.push(vec![]);
+
+        ConstraintSetHandle {
+            system_id: self.id,
+            id: id.try_into().expect("less than 2^32 constraint sets"),
+        }
+    }
+
+    /// Add an element.
+    ///
+    /// Give the element sets the element belongs to in `sets`.
+    pub fn add_element<T: Element>(
+        &mut self,
+        sets: &[&ElementSetHandle],
+        element: T,
+    ) -> ElementHandle<T> {
+        let id = self
+            .element_vertices
+            .len()
+            .try_into()
+            .expect("less than 2^32 elements");
+
+        element.add_into(&mut self.element_vertices, &mut self.variables);
+
+        let handle = ElementHandle::from_ids(self.id, id);
+        for set in sets {
+            assert_eq!(self.id, set.system_id);
+            self.element_sets[set.id as usize].push(handle.drop_system_id());
+        }
+
+        handle
+    }
+
+    /// Get the value of an element.
+    pub fn get_element<T: Element>(&self, element: ElementHandle<T>) -> T {
+        assert_eq!(self.id, element.system_id);
+
+        T::from_vertex(
+            &self.element_vertices[element.drop_system_id().id as usize],
+            &self.variables,
+        )
+    }
+
+    /// Add a constraint.
+    ///
+    /// Give the constraint sets the constraint belongs to in `sets`.
+    pub fn add_constraint<T: Constraint>(
+        &mut self,
+        sets: &[&ConstraintSetHandle],
+        constraint: T,
+    ) -> ConstraintHandle<T> {
+        let id = self
+            .constraint_edges
+            .len()
+            .try_into()
+            .expect("less than 2^32 constraints");
+        self.constraint_edges
+            .push(constraint.as_edge(&self.element_vertices));
+
+        let handle = ConstraintHandle::from_ids(self.id, id);
+        for set in sets {
+            assert_eq!(self.id, set.system_id);
+            self.constraint_sets[set.id as usize].push(handle.drop_system_id());
+        }
+
+        handle
+    }
+
+    /// Solve the system.
+    ///
+    /// The system is solved for constraints in `constraint_set`. Values of elements in
+    /// `element_set` are free variables. Other values are taken as fixed parameters. Note handle
+    /// values (such as the center point of a circle) are free if and only if the element the
+    /// handle corresponds to is in `element_set`, regardless of whether the circle itself is in
+    /// `element_set`.
+    pub fn solve(&mut self, element_set: &ElementSetHandle, constraint_set: &ConstraintSetHandle) {
+        crate::solve::levenberg_marquardt(
+            &mut self.variables,
+            &self.element_sets[element_set.id as usize],
+            &self.constraint_sets[constraint_set.id as usize],
+            &self.element_vertices,
+            &self.constraint_edges,
+        );
+    }
 }

--- a/fiksi/src/lib.rs
+++ b/fiksi/src/lib.rs
@@ -286,3 +286,11 @@ impl Default for System {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    // CI will fail unless cargo nextest can execute at least one test per workspace.
+    // Delete this dummy test once we have an actual real test.
+    #[test]
+    fn dummy_test_until_we_have_a_real_test() {}
+}

--- a/fiksi/src/lib.rs
+++ b/fiksi/src/lib.rs
@@ -82,6 +82,8 @@ use elements::element::ElementId;
 pub use elements::{Element, element::ElementHandle};
 
 /// Vertices are the geometric elements of the constraint system.
+///
+/// The indices point into the start of the vertex's variables in [`System::variables`].
 pub(crate) enum Vertex {
     Point { idx: u32 },
     Line { point1_idx: u32, point2_idx: u32 },
@@ -135,11 +137,14 @@ pub struct ConstraintSetHandle {
 /// [constraints](System::add_constraint). Then solve (sub)systems using [`System::solve`].
 pub struct System {
     id: u32,
+    /// Geometric elements.
+    element_vertices: Vec<Vertex>,
+    /// Constraints between geometric elements.
+    constraint_edges: Vec<Edge>,
+    /// The variables of the geometric elements, such as point coordinates.
     variables: Vec<f64>,
     element_sets: Vec<Vec<ElementId>>,
     constraint_sets: Vec<Vec<ConstraintId>>,
-    element_vertices: Vec<Vertex>,
-    constraint_edges: Vec<Edge>,
 }
 
 impl System {

--- a/fiksi/src/solve/lm.rs
+++ b/fiksi/src/solve/lm.rs
@@ -1,0 +1,175 @@
+use core::f64;
+
+use alloc::{vec, vec::Vec};
+
+use crate::{
+    ConstraintId, Edge, ElementId, Vertex,
+    constraints::{PointPointDistance_, PointPointPointAngle_},
+};
+
+/// The Levenberg-Marquardt solver.
+///
+/// Solve for the free variables in `variables` minimizing the residuals of the constraints in
+/// `constraint_set`. The variables given by the elements in `element_set` are seen as free, other
+/// variables are seen as fixed parameters.
+pub(crate) fn levenberg_marquardt(
+    variables: &mut [f64],
+    // TODO: actually use `element_set`
+    _element_set: &[ElementId],
+    constraint_set: &[ConstraintId],
+    element_vertices: &[Vertex],
+    constraint_edges: &[Edge],
+) {
+    // TODO: this is allocation-happy.
+    // TODO: we don't use enough of nalgebra here to justify including that dependency.
+
+    let mut lambda = 10.;
+    let mut prev_residual = f64::INFINITY;
+
+    let mut free_variables: Vec<u32> = vec![];
+    for vertex in element_vertices {
+        match vertex {
+            Vertex::Point { idx } => {
+                free_variables.extend(&[*idx, idx + 1]);
+            }
+            // In the current setup, not all vertices in the set contribute free variables. E.g.
+            // `Vertex::Line` only refers to existing points, meaning it does not contribute its
+            // own free variables. `Vertex::Circle` would refer to a point and has a radius as free
+            // variable.
+            _ => {}
+        }
+    }
+    free_variables.sort_unstable();
+    let mut index_map = alloc::collections::BTreeMap::new();
+    for (idx, &free_variable) in free_variables.iter().enumerate() {
+        index_map.insert(free_variable, idx as u32);
+    }
+
+    let constraints: Vec<&Edge> = constraint_set
+        .iter()
+        .map(|id| &constraint_edges[id.id as usize])
+        .collect();
+
+    // The (non-squared) residuals of the constraints.
+    let mut residuals = vec![0.; constraints.len()];
+    // All first-order partial derivatives of the constraints. This is a dense representation (each
+    // pair of constraint and variable has a partial derivative represented here, even for
+    // variables that do not contribute to the constraint). It's possible a sparse representation
+    // may be more efficient in certain cases.
+    let mut jacobian = vec![0.; constraints.len() * free_variables.len()];
+
+    // J^T * J square matrix.
+    // let mut jtj = vec![0.; free_variables.len() * free_variables.len()];
+
+    for _ in 0..100 {
+        jacobian.fill(0.);
+        residuals.fill(0.);
+
+        for (constraint_idx, &constraint) in constraints.iter().enumerate() {
+            match constraint {
+                &Edge::PointPointDistance {
+                    point1_idx,
+                    point2_idx,
+                    distance,
+                } => {
+                    PointPointDistance_ {
+                        point1_idx,
+                        point2_idx,
+                        distance,
+                    }
+                    .compute_residual_and_partial_derivatives(
+                        &index_map,
+                        &*variables,
+                        &mut residuals[constraint_idx],
+                        &mut jacobian[constraint_idx * free_variables.len()
+                            ..(constraint_idx + 1) * free_variables.len()],
+                    );
+                }
+                &Edge::PointPointPointAngle {
+                    point1_idx,
+                    point2_idx,
+                    point3_idx,
+                    angle,
+                } => {
+                    PointPointPointAngle_ {
+                        point1_idx,
+                        point2_idx,
+                        point3_idx,
+                        angle,
+                    }
+                    .compute_residual_and_partial_derivatives(
+                        &index_map,
+                        &*variables,
+                        &mut residuals[constraint_idx],
+                        &mut jacobian[constraint_idx * free_variables.len()
+                            ..(constraint_idx + 1) * free_variables.len()],
+                    );
+                }
+                &Edge::LineLineAngle { .. } => {}
+            }
+        }
+        let residuals_ = nalgebra::DVector::from_column_slice(&residuals);
+        let residual = residuals_.norm();
+
+        // TODO: revisit stopping conditions and the `lambda` schedule.
+        if residual < 1e-4 {
+            break;
+        }
+
+        if residual < prev_residual {
+            lambda *= 0.5;
+            if lambda < 1e-10 {
+                lambda = 1e-10;
+            }
+        } else {
+            lambda *= 2.;
+        }
+        prev_residual = residual;
+
+        // Clone the Jacobian to a nalgebra matrix for now.
+        // TODO: remove
+        let mut jacobian_ = nalgebra::DMatrix::zeros(constraints.len(), free_variables.len());
+        for i in 0..constraints.len() {
+            for j in 0..free_variables.len() {
+                jacobian_[(i, j)] = jacobian[i * free_variables.len() + j];
+            }
+        }
+
+        // calculate_jtj(&jacobian, &mut jtj, constraints.len(), free_variables.len());
+        // Augment JTJ by the damping factor `lambda`
+        // for i in 0..free_variables.len() {
+        //     jtj[i * free_variables.len() + i] += lambda;
+        // }
+
+        // Calculate J^T J and augment by the damping factor `lambda`.
+        let jtj_: nalgebra::DMatrix<f64> = (&jacobian_).transpose() * (&jacobian_)
+            + lambda * nalgebra::DMatrix::identity(free_variables.len(), free_variables.len());
+
+        let gradient = -(&jacobian_).transpose() * residuals_;
+
+        if let Some(delta) = jtj_.clone().lu().solve(&gradient) {
+            if delta.norm() < 1e-6 {
+                break;
+            }
+            for (idx, variable) in free_variables.iter().enumerate() {
+                variables[*variable as usize] += delta[idx];
+            }
+        } else {
+            panic!("Levenberg-Marquardt: failed to solve linear system");
+        }
+    }
+}
+
+// /// Calculate the J^T * J square matrix.
+// fn calculate_jtj(jacobian: &[f64], jtj: &mut [f64], constraints: usize, variables: usize) {
+//     for i in 0..variables {
+//         for j in 0..variables {
+//             let idx = i * variables + j;
+//             jtj[idx] = 0.;
+//
+//             for c in 0..constraints {
+//                 jtj[idx] += jacobian[c * variables + i] * jacobian[c * variables + j];
+//             }
+//         }
+//     }
+// }

--- a/fiksi/src/solve/lm.rs
+++ b/fiksi/src/solve/lm.rs
@@ -1,3 +1,6 @@
+// Copyright 2025 the Fiksi Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use core::f64;
 
 use alloc::{vec, vec::Vec};

--- a/fiksi/src/solve/mod.rs
+++ b/fiksi/src/solve/mod.rs
@@ -1,0 +1,3 @@
+mod lm;
+
+pub(crate) use lm::*;

--- a/fiksi/src/solve/mod.rs
+++ b/fiksi/src/solve/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2025 the Fiksi Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 mod lm;
 
 pub(crate) use lm::*;


### PR DESCRIPTION
This adds a limited number of constraints: two. (Point-point distance and point-point-point angle.) Levenberg-Marquardt is implemented as the solver; this method may be usable as a general solver, as it should be able to handle under- and overconstrained systems. It will be interesting to compare its performance (both in solving quality and efficiency) to, e.g., (L-)BFGS as the general solver.

As the initial and experimental API, the constraint system is set up to have separate elements and constraints. When an element is added, a handle to it is returned that can be used to construct constraints. To allow the user to choose various subsets to solve, elements and constraints can be added to sets that the user can hand to the `System::solve` method. (The API is a bit underbaked, once we gather more insight into the solver we'll get a better picture of what it should look like.)

It is not yet very ergonomic to get elements in or out of the system, it would be ideal to use Kurbo types, especially for output. For input, it's somewhat harder, e.g., when inputting a `Line` you may want to reuse existing `Point`s.