### PR TITLE
Add point-line incidence constraint

### DIFF
--- a/fiksi/src/elements/mod.rs
+++ b/fiksi/src/elements/mod.rs
@@ -83,22 +83,22 @@ impl sealed::ElementInner for Point {
 
 /// A line defined by two endpoints.
 #[derive(Debug)]
-pub struct Line {
+pub struct Line<'el> {
     /// First point of the line.
-    pub point1: ElementHandle<Point>,
+    pub point1: &'el ElementHandle<Point>,
     /// Second point of the line.
-    pub point2: ElementHandle<Point>,
+    pub point2: &'el ElementHandle<Point>,
 }
 
-impl sealed::ElementInner for Line {
-    fn add_into(&self, vertices: &mut Vec<Vertex>, _data: &mut Vec<f64>) {
-        let &Vertex::Point { idx: point1_idx } = &vertices[self.point1.id as usize] else {
+impl<'el> sealed::ElementInner for Line<'el> {
+    fn add_into(&self, element_vertices: &mut Vec<Vertex>, _variables: &mut Vec<f64>) {
+        let &Vertex::Point { idx: point1_idx } = &element_vertices[self.point1.id as usize] else {
             unreachable!()
         };
-        let &Vertex::Point { idx: point2_idx } = &vertices[self.point2.id as usize] else {
+        let &Vertex::Point { idx: point2_idx } = &element_vertices[self.point2.id as usize] else {
             unreachable!()
         };
-        vertices.push(Vertex::Line {
+        element_vertices.push(Vertex::Line {
             point1_idx,
             point2_idx,
         });
@@ -139,4 +139,4 @@ pub(crate) mod sealed {
 pub trait Element: sealed::ElementInner {}
 
 impl Element for Point {}
-impl Element for Line {}
+impl<'el> Element for Line<'el> {}

--- a/fiksi/src/lib.rs
+++ b/fiksi/src/lib.rs
@@ -103,6 +103,11 @@ pub(crate) enum Edge {
         point3_idx: u32,
         angle: f64,
     },
+    PointLineIncidence {
+        point_idx: u32,
+        line_point1_idx: u32,
+        line_point2_idx: u32,
+    },
     LineLineAngle {
         point1_idx: u32,
         point2_idx: u32,

--- a/fiksi/src/utils.rs
+++ b/fiksi/src/utils.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     Edge,
-    constraints::{PointPointDistance_, PointPointPointAngle_},
+    constraints::{PointLineIncidence_, PointPointDistance_, PointPointPointAngle_},
 };
 
 /// Compute residuals and Jacobian for all constraints.
@@ -55,6 +55,24 @@ pub(crate) fn calculate_residuals_and_jacobian(
                     point2_idx,
                     point3_idx,
                     angle,
+                }
+                .compute_residual_and_partial_derivatives(
+                    free_variable_map,
+                    variables,
+                    &mut residuals[constraint_idx],
+                    &mut jacobian[constraint_idx * num_free_variables
+                        ..(constraint_idx + 1) * num_free_variables],
+                );
+            }
+            Edge::PointLineIncidence {
+                point_idx,
+                line_point1_idx,
+                line_point2_idx,
+            } => {
+                PointLineIncidence_ {
+                    point_idx,
+                    line_point1_idx,
+                    line_point2_idx,
                 }
                 .compute_residual_and_partial_derivatives(
                     free_variable_map,


### PR DESCRIPTION
Point-line incidence is a logical constraint, rather than a metric one. It's somewhat similar to the vertex angle (`PointPointPointAngle`), with an angle of 180 degrees, except for this incidence constraint it doesn't matter which point is the vertex point. This could be called `PointPointPointCollinearity` and use points rather than lines. We should think about exactly how we want to name and represent these elements and constraints.

This shows how in the current setup a `Line` just references two existing `Point`s.