### PR TITLE
Extract `calculate_residuals_and_jacobian` to `utils`

### DIFF
--- a/fiksi/src/constraints/mod.rs
+++ b/fiksi/src/constraints/mod.rs
@@ -118,7 +118,7 @@ pub(crate) struct PointPointDistance_ {
 impl PointPointDistance_ {
     pub(crate) fn compute_residual_and_partial_derivatives(
         &self,
-        index_map: &alloc::collections::BTreeMap<u32, u32>,
+        free_variable_map: &alloc::collections::BTreeMap<u32, u32>,
         variables: &[f64],
         residual: &mut f64,
         first_derivative: &mut [f64],
@@ -143,16 +143,16 @@ impl PointPointDistance_ {
             -(point1.y - point2.y) * distance_recip,
         ];
 
-        if let Some(idx) = index_map.get(&self.point1_idx) {
+        if let Some(idx) = free_variable_map.get(&self.point1_idx) {
             first_derivative[*idx as usize] += derivative[0];
         }
-        if let Some(idx) = index_map.get(&(self.point1_idx + 1)) {
+        if let Some(idx) = free_variable_map.get(&(self.point1_idx + 1)) {
             first_derivative[*idx as usize] += derivative[1];
         }
-        if let Some(idx) = index_map.get(&self.point2_idx) {
+        if let Some(idx) = free_variable_map.get(&self.point2_idx) {
             first_derivative[*idx as usize] += derivative[2];
         }
-        if let Some(idx) = index_map.get(&(self.point2_idx + 1)) {
+        if let Some(idx) = free_variable_map.get(&(self.point2_idx + 1)) {
             first_derivative[*idx as usize] += derivative[3];
         }
     }
@@ -223,7 +223,7 @@ pub(crate) struct PointPointPointAngle_ {
 impl PointPointPointAngle_ {
     pub(crate) fn compute_residual_and_partial_derivatives(
         &self,
-        index_map: &alloc::collections::BTreeMap<u32, u32>,
+        free_variable_map: &alloc::collections::BTreeMap<u32, u32>,
         variables: &[f64],
         residual: &mut f64,
         first_derivative: &mut [f64],
@@ -275,22 +275,22 @@ impl PointPointPointAngle_ {
             dangle_dpoint3y,
         ];
 
-        if let Some(idx) = index_map.get(&self.point1_idx) {
+        if let Some(idx) = free_variable_map.get(&self.point1_idx) {
             first_derivative[*idx as usize] += derivative[0];
         }
-        if let Some(idx) = index_map.get(&(self.point1_idx + 1)) {
+        if let Some(idx) = free_variable_map.get(&(self.point1_idx + 1)) {
             first_derivative[*idx as usize] += derivative[1];
         }
-        if let Some(idx) = index_map.get(&self.point2_idx) {
+        if let Some(idx) = free_variable_map.get(&self.point2_idx) {
             first_derivative[*idx as usize] += derivative[2];
         }
-        if let Some(idx) = index_map.get(&(self.point2_idx + 1)) {
+        if let Some(idx) = free_variable_map.get(&(self.point2_idx + 1)) {
             first_derivative[*idx as usize] += derivative[3];
         }
-        if let Some(idx) = index_map.get(&(self.point3_idx)) {
+        if let Some(idx) = free_variable_map.get(&(self.point3_idx)) {
             first_derivative[*idx as usize] += derivative[4];
         }
-        if let Some(idx) = index_map.get(&(self.point3_idx + 1)) {
+        if let Some(idx) = free_variable_map.get(&(self.point3_idx + 1)) {
             first_derivative[*idx as usize] += derivative[5];
         }
     }

--- a/fiksi/src/lib.rs
+++ b/fiksi/src/lib.rs
@@ -75,6 +75,7 @@ pub use kurbo;
 pub mod constraints;
 pub mod elements;
 pub mod solve;
+pub(crate) mod utils;
 
 pub(crate) use constraints::constraint::ConstraintId;
 pub use constraints::{Constraint, constraint::ConstraintHandle};

--- a/fiksi/src/solve/lbfgs.rs
+++ b/fiksi/src/solve/lbfgs.rs
@@ -94,13 +94,7 @@ pub(crate) fn lbfgs(
     // Gradient (`g_k`) scratch buffer.
     let mut gradient = vec![0.; num_variables];
     // Calculate initial gradient
-    compute_gradient(
-        &jacobian,
-        &residuals,
-        &mut gradient,
-        constraints.len(),
-        num_variables,
-    );
+    compute_gradient(&jacobian, &residuals, &mut gradient);
 
     // `MAX_HISTORY`-sized history storage for `s_k`, `y_k` and `ρ_k`.
     //
@@ -200,8 +194,6 @@ pub(crate) fn lbfgs(
             &index_map,
             variables,
             &mut variables_scratch,
-            constraints.len(),
-            num_variables,
             &mut jacobian,
             &mut residuals,
             &mut gradient,
@@ -239,14 +231,11 @@ pub(crate) fn lbfgs(
 ///
 /// Specifically, the gradient is ∇f(x) = ∇½||r||^2.
 #[inline]
-fn compute_gradient(
-    jacobian: &[f64],
-    residuals: &[f64],
-    gradient: &mut [f64],
-    num_constraints: usize,
-    num_variables: usize,
-) {
+fn compute_gradient(jacobian: &[f64], residuals: &[f64], gradient: &mut [f64]) {
     gradient.fill(0.0);
+
+    let num_variables = gradient.len();
+    let num_constraints = residuals.len();
 
     for i in 0..num_variables {
         for c in 0..num_constraints {
@@ -313,8 +302,6 @@ mod hager_zhang {
         index_map: &'a alloc::collections::BTreeMap<u32, u32>,
         variables: &'a [f64],
         variables_scratch: &'a mut [f64],
-        num_constraints: usize,
-        num_variables: usize,
         jacobian: &'a mut [f64],
         residuals: &'a mut [f64],
         gradient: &'a mut [f64],
@@ -334,13 +321,7 @@ mod hager_zhang {
                 self.residuals,
                 self.jacobian,
             );
-            compute_gradient(
-                self.jacobian,
-                self.residuals,
-                self.gradient,
-                self.num_constraints,
-                self.num_variables,
-            );
+            compute_gradient(self.jacobian, self.residuals, self.gradient);
             let phi = sum_squared_residuals(self.residuals);
             let dphi = dot_product(self.gradient, self.direction);
 
@@ -536,8 +517,6 @@ mod hager_zhang {
         index_map: &alloc::collections::BTreeMap<u32, u32>,
         variables: &[f64],
         variables_scratch: &mut [f64],
-        num_constraints: usize,
-        num_variables: usize,
         jacobian: &mut [f64],
         residuals: &mut [f64],
         gradient: &mut [f64],
@@ -553,8 +532,6 @@ mod hager_zhang {
             index_map,
             variables,
             variables_scratch,
-            num_constraints,
-            num_variables,
             jacobian,
             residuals,
             gradient,

--- a/fiksi/src/solve/lbfgs.rs
+++ b/fiksi/src/solve/lbfgs.rs
@@ -58,9 +58,9 @@ pub(crate) fn lbfgs(
 
     // Map from variable index into free variable index within the Jacobian matrix, gradient
     // vector, etc.
-    let mut index_map = alloc::collections::BTreeMap::new();
+    let mut free_variable_map = alloc::collections::BTreeMap::new();
     for (idx, &free_variable) in free_variables.iter().enumerate() {
-        index_map.insert(
+        free_variable_map.insert(
             free_variable,
             idx.try_into().expect("less than 2^32 elements"),
         );
@@ -80,7 +80,7 @@ pub(crate) fn lbfgs(
     // Calculate initial residuals and gradients
     calculate_residuals_and_jacobian(
         &constraints,
-        &index_map,
+        &free_variable_map,
         variables,
         &mut residuals,
         &mut jacobian,
@@ -191,7 +191,7 @@ pub(crate) fn lbfgs(
         let step_size_ = hager_zhang::line_search(
             &constraints,
             &free_variables,
-            &index_map,
+            &free_variable_map,
             variables,
             &mut variables_scratch,
             &mut jacobian,
@@ -299,7 +299,7 @@ mod hager_zhang {
     struct Eval<'a> {
         constraints: &'a [&'a Edge],
         free_variables: &'a [u32],
-        index_map: &'a alloc::collections::BTreeMap<u32, u32>,
+        free_variable_map: &'a alloc::collections::BTreeMap<u32, u32>,
         variables: &'a [f64],
         variables_scratch: &'a mut [f64],
         jacobian: &'a mut [f64],
@@ -316,7 +316,7 @@ mod hager_zhang {
 
             calculate_residuals_and_jacobian(
                 self.constraints,
-                self.index_map,
+                self.free_variable_map,
                 self.variables_scratch,
                 self.residuals,
                 self.jacobian,
@@ -514,7 +514,7 @@ mod hager_zhang {
     pub(super) fn line_search(
         constraints: &[&Edge],
         free_variables: &[u32],
-        index_map: &alloc::collections::BTreeMap<u32, u32>,
+        free_variable_map: &alloc::collections::BTreeMap<u32, u32>,
         variables: &[f64],
         variables_scratch: &mut [f64],
         jacobian: &mut [f64],
@@ -529,7 +529,7 @@ mod hager_zhang {
         let eval = &mut Eval {
             constraints,
             free_variables,
-            index_map,
+            free_variable_map,
             variables,
             variables_scratch,
             jacobian,

--- a/fiksi/src/solve/lm.rs
+++ b/fiksi/src/solve/lm.rs
@@ -41,9 +41,9 @@ pub(crate) fn levenberg_marquardt(
         }
     }
     free_variables.sort_unstable();
-    let mut index_map = alloc::collections::BTreeMap::new();
+    let mut free_variable_map = alloc::collections::BTreeMap::new();
     for (idx, &free_variable) in free_variables.iter().enumerate() {
-        index_map.insert(
+        free_variable_map.insert(
             free_variable,
             idx.try_into().expect("less than 2^32 elements"),
         );
@@ -68,7 +68,7 @@ pub(crate) fn levenberg_marquardt(
     for _ in 0..100 {
         calculate_residuals_and_jacobian(
             &constraints,
-            &index_map,
+            &free_variable_map,
             variables,
             &mut residuals,
             &mut jacobian,

--- a/fiksi/src/utils.rs
+++ b/fiksi/src/utils.rs
@@ -1,0 +1,71 @@
+// Copyright 2025 the Fiksi Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Utility functions.
+
+use crate::{
+    Edge,
+    constraints::{PointPointDistance_, PointPointPointAngle_},
+};
+
+/// Compute residuals and Jacobian for all constraints.
+///
+/// The Jacobian is relative to the free variables.
+pub(crate) fn calculate_residuals_and_jacobian(
+    constraints: &[&Edge],
+    index_map: &alloc::collections::BTreeMap<u32, u32>,
+    variables: &[f64],
+    residuals: &mut [f64],
+    jacobian: &mut [f64],
+) {
+    jacobian.fill(0.);
+    residuals.fill(0.);
+
+    let num_free_variables = index_map.len();
+
+    for (constraint_idx, &constraint) in constraints.iter().enumerate() {
+        match *constraint {
+            Edge::PointPointDistance {
+                point1_idx,
+                point2_idx,
+                distance,
+            } => {
+                PointPointDistance_ {
+                    point1_idx,
+                    point2_idx,
+                    distance,
+                }
+                .compute_residual_and_partial_derivatives(
+                    index_map,
+                    variables,
+                    &mut residuals[constraint_idx],
+                    &mut jacobian[constraint_idx * num_free_variables
+                        ..(constraint_idx + 1) * num_free_variables],
+                );
+            }
+            Edge::PointPointPointAngle {
+                point1_idx,
+                point2_idx,
+                point3_idx,
+                angle,
+            } => {
+                PointPointPointAngle_ {
+                    point1_idx,
+                    point2_idx,
+                    point3_idx,
+                    angle,
+                }
+                .compute_residual_and_partial_derivatives(
+                    index_map,
+                    variables,
+                    &mut residuals[constraint_idx],
+                    &mut jacobian[constraint_idx * num_free_variables
+                        ..(constraint_idx + 1) * num_free_variables],
+                );
+            }
+            Edge::LineLineAngle { .. } => {
+                unimplemented!()
+            }
+        }
+    }
+}

--- a/fiksi/src/utils.rs
+++ b/fiksi/src/utils.rs
@@ -13,7 +13,8 @@ use crate::{
 /// The Jacobian is relative to the free variables.
 pub(crate) fn calculate_residuals_and_jacobian(
     constraints: &[&Edge],
-    index_map: &alloc::collections::BTreeMap<u32, u32>,
+    // Map from variable indices (in `variables`) to free variable indices.
+    free_variable_map: &alloc::collections::BTreeMap<u32, u32>,
     variables: &[f64],
     residuals: &mut [f64],
     jacobian: &mut [f64],
@@ -21,7 +22,7 @@ pub(crate) fn calculate_residuals_and_jacobian(
     jacobian.fill(0.);
     residuals.fill(0.);
 
-    let num_free_variables = index_map.len();
+    let num_free_variables = free_variable_map.len();
 
     for (constraint_idx, &constraint) in constraints.iter().enumerate() {
         match *constraint {
@@ -36,7 +37,7 @@ pub(crate) fn calculate_residuals_and_jacobian(
                     distance,
                 }
                 .compute_residual_and_partial_derivatives(
-                    index_map,
+                    free_variable_map,
                     variables,
                     &mut residuals[constraint_idx],
                     &mut jacobian[constraint_idx * num_free_variables
@@ -56,7 +57,7 @@ pub(crate) fn calculate_residuals_and_jacobian(
                     angle,
                 }
                 .compute_residual_and_partial_derivatives(
-                    index_map,
+                    free_variable_map,
                     variables,
                     &mut residuals[constraint_idx],
                     &mut jacobian[constraint_idx * num_free_variables


### PR DESCRIPTION
This functionality is needed for L-BFGS and Levenberg-Marquardt, and is currently defined twice.

While we're here, this cleans up some unnecessary parameters passed to the gradient calculation function in L-BFGS. Also improves naming of the "free variable map" (though I'm not entirely happy with how variables, constraints, free variables are represented at the moment).