### PR TITLE
Add line-circle tangency constraint

### DIFF
--- a/fiksi/src/lib.rs
+++ b/fiksi/src/lib.rs
@@ -88,6 +88,7 @@ pub use elements::{Element, element::ElementHandle};
 pub(crate) enum Vertex {
     Point { idx: u32 },
     Line { point1_idx: u32, point2_idx: u32 },
+    Circle { midpoint_idx: u32, radius_idx: u32 },
 }
 
 /// Edges are the constraints between geometric elements (i.e., edges between the vertices).
@@ -114,6 +115,12 @@ pub(crate) enum Edge {
         point3_idx: u32,
         point4_idx: u32,
         angle: f64,
+    },
+    LineCircleTangency {
+        line_point1_idx: u32,
+        line_point2_idx: u32,
+        circle_midpoint_idx: u32,
+        circle_radius_idx: u32,
     },
 }
 

--- a/fiksi/src/solve/lbfgs.rs
+++ b/fiksi/src/solve/lbfgs.rs
@@ -44,10 +44,12 @@ pub(crate) fn lbfgs(
     // index.
     let mut free_variables: Vec<u32> = vec![];
     for vertex in element_vertices {
-        #[expect(clippy::single_match, reason = "more to follow")]
         match vertex {
             Vertex::Point { idx } => {
                 free_variables.extend(&[*idx, idx + 1]);
+            }
+            Vertex::Circle { radius_idx, .. } => {
+                free_variables.extend(&[*radius_idx]);
             }
             // In the current setup, not all vertices in the set contribute free variables.
             _ => {}

--- a/fiksi/src/solve/lm.rs
+++ b/fiksi/src/solve/lm.rs
@@ -28,15 +28,17 @@ pub(crate) fn levenberg_marquardt(
 
     let mut free_variables: Vec<u32> = vec![];
     for vertex in element_vertices {
-        #[expect(clippy::single_match, reason = "more to follow")]
         match vertex {
             Vertex::Point { idx } => {
                 free_variables.extend(&[*idx, idx + 1]);
             }
             // In the current setup, not all vertices in the set contribute free variables. E.g.
             // `Vertex::Line` only refers to existing points, meaning it does not contribute its
-            // own free variables. `Vertex::Circle` would refer to a point and has a radius as free
+            // own free variables. `Vertex::Circle` refers to a point and has a radius as free
             // variable.
+            Vertex::Circle { radius_idx, .. } => {
+                free_variables.extend(&[*radius_idx]);
+            }
             _ => {}
         }
     }

--- a/fiksi/src/utils.rs
+++ b/fiksi/src/utils.rs
@@ -5,7 +5,9 @@
 
 use crate::{
     Edge,
-    constraints::{PointLineIncidence_, PointPointDistance_, PointPointPointAngle_},
+    constraints::{
+        LineCircleTangency_, PointLineIncidence_, PointPointDistance_, PointPointPointAngle_,
+    },
 };
 
 /// Compute residuals and Jacobian for all constraints.
@@ -73,6 +75,26 @@ pub(crate) fn calculate_residuals_and_jacobian(
                     point_idx,
                     line_point1_idx,
                     line_point2_idx,
+                }
+                .compute_residual_and_partial_derivatives(
+                    free_variable_map,
+                    variables,
+                    &mut residuals[constraint_idx],
+                    &mut jacobian[constraint_idx * num_free_variables
+                        ..(constraint_idx + 1) * num_free_variables],
+                );
+            }
+            Edge::LineCircleTangency {
+                line_point1_idx,
+                line_point2_idx,
+                circle_midpoint_idx,
+                circle_radius_idx,
+            } => {
+                LineCircleTangency_ {
+                    line_point1_idx,
+                    line_point2_idx,
+                    circle_midpoint_idx,
+                    circle_radius_idx,
                 }
                 .compute_residual_and_partial_derivatives(
                     free_variable_map,


### PR DESCRIPTION
One thing of interest here is that circles have three variables (2D midpoint and radius), whereas the `Point` and `Line` elements have two and four variables respectively. This means variables don't necessarily come in pairs of two anymore.