### PR TITLE
Simplify constraint storage

### DIFF
--- a/fiksi/src/constraints/mod.rs
+++ b/fiksi/src/constraints/mod.rs
@@ -78,11 +78,11 @@ impl sealed::ConstraintInner for PointPointDistance {
         let &Vertex::Point { idx: point2_idx } = &vertices[self.point2.id as usize] else {
             unreachable!()
         };
-        Edge::PointPointDistance {
+        Edge::PointPointDistance(PointPointDistance_ {
             point1_idx,
             point2_idx,
             distance: self.distance,
-        }
+        })
     }
 }
 
@@ -179,12 +179,12 @@ impl sealed::ConstraintInner for PointPointPointAngle {
         let &Vertex::Point { idx: point3_idx } = &vertices[self.point3.id as usize] else {
             unreachable!()
         };
-        Edge::PointPointPointAngle {
+        Edge::PointPointPointAngle(PointPointPointAngle_ {
             point1_idx,
             point2_idx,
             point3_idx,
             angle: self.angle,
-        }
+        })
     }
 }
 
@@ -398,11 +398,11 @@ impl sealed::ConstraintInner for PointLineIncidence {
         else {
             unreachable!()
         };
-        Edge::PointLineIncidence {
+        Edge::PointLineIncidence(PointLineIncidence_ {
             point_idx,
             line_point1_idx,
             line_point2_idx,
-        }
+        })
     }
 }
 
@@ -433,13 +433,13 @@ impl sealed::ConstraintInner for LineLineAngle<'_> {
         else {
             unreachable!()
         };
-        Edge::LineLineAngle {
+        Edge::LineLineAngle(LineLineAngle_ {
             point1_idx,
             point2_idx,
             point3_idx,
             point4_idx,
             angle: self.angle,
-        }
+        })
     }
 }
 
@@ -480,12 +480,12 @@ impl sealed::ConstraintInner for LineCircleTangency {
         else {
             unreachable!()
         };
-        Edge::LineCircleTangency {
+        Edge::LineCircleTangency(LineCircleTangency_ {
             line_point1_idx,
             line_point2_idx,
             circle_center_idx,
             circle_radius_idx,
-        }
+        })
     }
 }
 

--- a/fiksi/src/lib.rs
+++ b/fiksi/src/lib.rs
@@ -82,6 +82,11 @@ pub use constraints::{Constraint, constraint::ConstraintHandle};
 use elements::element::ElementId;
 pub use elements::{Element, element::ElementHandle};
 
+use crate::constraints::{
+    LineCircleTangency_, LineLineAngle_, PointLineIncidence_, PointPointDistance_,
+    PointPointPointAngle_,
+};
+
 /// Vertices are the geometric elements of the constraint system.
 ///
 /// The indices point into the start of the vertex's variables in [`System::variables`].
@@ -93,35 +98,11 @@ pub(crate) enum Vertex {
 
 /// Edges are the constraints between geometric elements (i.e., edges between the vertices).
 pub(crate) enum Edge {
-    PointPointDistance {
-        point1_idx: u32,
-        point2_idx: u32,
-        distance: f64,
-    },
-    PointPointPointAngle {
-        point1_idx: u32,
-        point2_idx: u32,
-        point3_idx: u32,
-        angle: f64,
-    },
-    PointLineIncidence {
-        point_idx: u32,
-        line_point1_idx: u32,
-        line_point2_idx: u32,
-    },
-    LineLineAngle {
-        point1_idx: u32,
-        point2_idx: u32,
-        point3_idx: u32,
-        point4_idx: u32,
-        angle: f64,
-    },
-    LineCircleTangency {
-        line_point1_idx: u32,
-        line_point2_idx: u32,
-        circle_center_idx: u32,
-        circle_radius_idx: u32,
-    },
+    PointPointDistance(PointPointDistance_),
+    PointPointPointAngle(PointPointPointAngle_),
+    PointLineIncidence(PointLineIncidence_),
+    LineLineAngle(LineLineAngle_),
+    LineCircleTangency(LineCircleTangency_),
 }
 
 /// A handle to an element set.

--- a/fiksi/src/utils.rs
+++ b/fiksi/src/utils.rs
@@ -3,12 +3,7 @@
 
 //! Utility functions.
 
-use crate::{
-    Edge,
-    constraints::{
-        LineCircleTangency_, PointLineIncidence_, PointPointDistance_, PointPointPointAngle_,
-    },
-};
+use crate::Edge;
 
 /// Compute residuals and Jacobian for all constraints.
 ///
@@ -27,18 +22,9 @@ pub(crate) fn calculate_residuals_and_jacobian(
     let num_free_variables = free_variable_map.len();
 
     for (constraint_idx, &constraint) in constraints.iter().enumerate() {
-        match *constraint {
-            Edge::PointPointDistance {
-                point1_idx,
-                point2_idx,
-                distance,
-            } => {
-                PointPointDistance_ {
-                    point1_idx,
-                    point2_idx,
-                    distance,
-                }
-                .compute_residual_and_partial_derivatives(
+        match constraint {
+            Edge::PointPointDistance(constraint) => {
+                constraint.compute_residual_and_partial_derivatives(
                     free_variable_map,
                     variables,
                     &mut residuals[constraint_idx],
@@ -46,19 +32,8 @@ pub(crate) fn calculate_residuals_and_jacobian(
                         ..(constraint_idx + 1) * num_free_variables],
                 );
             }
-            Edge::PointPointPointAngle {
-                point1_idx,
-                point2_idx,
-                point3_idx,
-                angle,
-            } => {
-                PointPointPointAngle_ {
-                    point1_idx,
-                    point2_idx,
-                    point3_idx,
-                    angle,
-                }
-                .compute_residual_and_partial_derivatives(
+            Edge::PointPointPointAngle(constraint) => {
+                constraint.compute_residual_and_partial_derivatives(
                     free_variable_map,
                     variables,
                     &mut residuals[constraint_idx],
@@ -66,17 +41,8 @@ pub(crate) fn calculate_residuals_and_jacobian(
                         ..(constraint_idx + 1) * num_free_variables],
                 );
             }
-            Edge::PointLineIncidence {
-                point_idx,
-                line_point1_idx,
-                line_point2_idx,
-            } => {
-                PointLineIncidence_ {
-                    point_idx,
-                    line_point1_idx,
-                    line_point2_idx,
-                }
-                .compute_residual_and_partial_derivatives(
+            Edge::PointLineIncidence(constraint) => {
+                constraint.compute_residual_and_partial_derivatives(
                     free_variable_map,
                     variables,
                     &mut residuals[constraint_idx],
@@ -84,19 +50,8 @@ pub(crate) fn calculate_residuals_and_jacobian(
                         ..(constraint_idx + 1) * num_free_variables],
                 );
             }
-            Edge::LineCircleTangency {
-                line_point1_idx,
-                line_point2_idx,
-                circle_center_idx,
-                circle_radius_idx,
-            } => {
-                LineCircleTangency_ {
-                    line_point1_idx,
-                    line_point2_idx,
-                    circle_center_idx,
-                    circle_radius_idx,
-                }
-                .compute_residual_and_partial_derivatives(
+            Edge::LineCircleTangency(constraint) => {
+                constraint.compute_residual_and_partial_derivatives(
                     free_variable_map,
                     variables,
                     &mut residuals[constraint_idx],


### PR DESCRIPTION
It may be possible to simplify this more and get rid of the duplicate constraint struct definitions (merging `PointPointDistance` as the public type and `PointPointDistance_` as the internal struct for calculation), but that would require having access to the variable indices of elements in some way during construction of the constraint.