### PR TITLE
Simplify element handles, drop lifetimes

### DIFF
--- a/fiksi/README.md
+++ b/fiksi/README.md
@@ -50,15 +50,15 @@ let p3 = gcs.add_element(&[&element_set], fiksi::elements::Point::new(1.1, 2.));
 
 gcs.add_constraint(
     &[&constraint_set],
-    fiksi::constraints::PointPointDistance::new(&p2, &p3, 5.),
+    fiksi::constraints::PointPointDistance::new(p2, p3, 5.),
 );
 gcs.add_constraint(
     &[&constraint_set],
-    fiksi::constraints::PointPointPointAngle::new(&p1, &p2, &p3, 10f64.to_radians()),
+    fiksi::constraints::PointPointPointAngle::new(p1, p2, p3, 10f64.to_radians()),
 );
 gcs.add_constraint(
     &[&constraint_set],
-    fiksi::constraints::PointPointPointAngle::new(&p2, &p3, &p1, 60f64.to_radians()),
+    fiksi::constraints::PointPointPointAngle::new(p2, p3, p1, 60f64.to_radians()),
 );
 gcs.solve(&element_set, &constraint_set, fiksi::SolvingOptions::DEFAULT);
 ```

--- a/fiksi/src/constraints/mod.rs
+++ b/fiksi/src/constraints/mod.rs
@@ -31,7 +31,6 @@ pub(crate) mod constraint {
     use core::marker::PhantomData;
 
     /// A handle to a constraint within a [`System`](crate::System).
-    #[derive(Debug)]
     pub struct ConstraintHandle<T> {
         /// The ID of the system the constraint belongs to.
         system_id: u32,
@@ -51,6 +50,43 @@ pub(crate) mod constraint {
 
         pub(crate) fn drop_system_id(&self) -> ConstraintId {
             ConstraintId { id: self.id }
+        }
+    }
+
+    impl<T> core::fmt::Debug for ConstraintHandle<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            let mut s = f.debug_struct("ConstraintHandle");
+            s.field("system_id", &self.system_id);
+            s.field("id", &self.id);
+            s.finish()
+        }
+    }
+
+    impl<T> Clone for ConstraintHandle<T> {
+        fn clone(&self) -> Self {
+            Self {
+                _t: PhantomData::default(),
+                ..*self
+            }
+        }
+    }
+    impl<T> Copy for ConstraintHandle<T> {}
+
+    impl<T> PartialEq for ConstraintHandle<T> {
+        fn eq(&self, other: &Self) -> bool {
+            self.system_id == other.system_id && self.id == other.id
+        }
+    }
+    impl<T> Eq for ConstraintHandle<T> {}
+
+    impl<T> Ord for ConstraintHandle<T> {
+        fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+            (self.system_id, self.id).cmp(&(other.system_id, other.id))
+        }
+    }
+    impl<T> PartialOrd for ConstraintHandle<T> {
+        fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+            Some(self.cmp(other))
         }
     }
 
@@ -91,8 +127,8 @@ impl PointPointDistance {
     ///
     /// `distance` is the Euclidean distance between `point1` and `point2`.
     pub fn new(
-        point1: &ElementHandle<elements::Point>,
-        point2: &ElementHandle<elements::Point>,
+        point1: ElementHandle<elements::Point>,
+        point2: ElementHandle<elements::Point>,
         distance: f64,
     ) -> Self {
         Self {
@@ -193,9 +229,9 @@ impl PointPointPointAngle {
     ///
     /// `angle` is the angle in radians the points should describe.
     pub fn new(
-        point1: &ElementHandle<elements::Point>,
-        point2: &ElementHandle<elements::Point>,
-        point3: &ElementHandle<elements::Point>,
+        point1: ElementHandle<elements::Point>,
+        point2: ElementHandle<elements::Point>,
+        point3: ElementHandle<elements::Point>,
         angle: f64,
     ) -> Self {
         Self {
@@ -309,10 +345,7 @@ pub struct PointLineIncidence {
 impl PointLineIncidence {
     /// Construct a constraint between a point and a line such that the point lies on the
     /// (infinite) line.
-    pub fn new(
-        point: &ElementHandle<elements::Point>,
-        line: &ElementHandle<elements::Line<'_>>,
-    ) -> Self {
+    pub fn new(point: ElementHandle<elements::Point>, line: ElementHandle<elements::Line>) -> Self {
         Self {
             point: point.drop_system_id(),
             line: line.drop_system_id(),
@@ -409,15 +442,15 @@ impl sealed::ConstraintInner for PointLineIncidence {
 /// Constrain two lines to describe a given angle.
 ///
 /// TODO: actually implement this, or require using [`PointPointPointAngle`]?
-pub struct LineLineAngle<'el> {
-    line1: ElementHandle<elements::Line<'el>>,
-    line2: ElementHandle<elements::Line<'el>>,
+pub struct LineLineAngle {
+    line1: ElementHandle<elements::Line>,
+    line2: ElementHandle<elements::Line>,
 
     /// Angle in radians.
     angle: f64,
 }
 
-impl sealed::ConstraintInner for LineLineAngle<'_> {
+impl sealed::ConstraintInner for LineLineAngle {
     fn as_edge(&self, vertices: &[Vertex]) -> Edge {
         let &Vertex::Line {
             point1_idx,
@@ -493,8 +526,8 @@ impl LineCircleTangency {
     /// Construct a constraint between a line and a circle such that the line is tangent on the
     /// circle.
     pub fn new(
-        line: &ElementHandle<elements::Line<'_>>,
-        circle: &ElementHandle<elements::Circle<'_>>,
+        line: ElementHandle<elements::Line>,
+        circle: ElementHandle<elements::Circle>,
     ) -> Self {
         Self {
             line: line.drop_system_id(),
@@ -610,4 +643,4 @@ impl Constraint for PointPointDistance {}
 impl Constraint for PointPointPointAngle {}
 impl Constraint for PointLineIncidence {}
 impl Constraint for LineCircleTangency {}
-impl Constraint for LineLineAngle<'_> {}
+impl Constraint for LineLineAngle {}

--- a/fiksi/src/lib.rs
+++ b/fiksi/src/lib.rs
@@ -28,15 +28,15 @@
 //!
 //! gcs.add_constraint(
 //!     &[&constraint_set],
-//!     fiksi::constraints::PointPointDistance::new(&p2, &p3, 5.),
+//!     fiksi::constraints::PointPointDistance::new(p2, p3, 5.),
 //! );
 //! gcs.add_constraint(
 //!     &[&constraint_set],
-//!     fiksi::constraints::PointPointPointAngle::new(&p1, &p2, &p3, 10f64.to_radians()),
+//!     fiksi::constraints::PointPointPointAngle::new(p1, p2, p3, 10f64.to_radians()),
 //! );
 //! gcs.add_constraint(
 //!     &[&constraint_set],
-//!     fiksi::constraints::PointPointPointAngle::new(&p2, &p3, &p1, 60f64.to_radians()),
+//!     fiksi::constraints::PointPointPointAngle::new(p2, p3, p1, 60f64.to_radians()),
 //! );
 //! gcs.solve(&element_set, &constraint_set, fiksi::SolvingOptions::DEFAULT);
 //! ```
@@ -246,7 +246,7 @@ impl System {
     }
 
     /// Get the value of an element.
-    pub fn get_element<T: Element>(&self, element: &ElementHandle<T>) -> <T as Element>::Output {
+    pub fn get_element<T: Element>(&self, element: ElementHandle<T>) -> <T as Element>::Output {
         // TODO: return `Result` instead of panicking?
         assert_eq!(
             self.id, element.system_id,
@@ -261,7 +261,7 @@ impl System {
     }
 
     /// Calculate the residual of a constraint.
-    pub fn calculate_constraint_residual<T>(&self, constraint: &ConstraintHandle<T>) -> f64 {
+    pub fn calculate_constraint_residual<T>(&self, constraint: ConstraintHandle<T>) -> f64 {
         let edge = &self.constraint_edges[constraint.drop_system_id().id as usize];
         let residual = &mut [0.];
         utils::calculate_residuals_and_jacobian(

--- a/fiksi/src/tests/basic.rs
+++ b/fiksi/src/tests/basic.rs
@@ -20,11 +20,11 @@ fn underconstrained_triangle() {
     let p3 = s.add_element(&[&element_set], elements::Point { x: 2., y: 1. });
     let angle1 = s.add_constraint(
         &[&constraint_set],
-        constraints::PointPointPointAngle::new(&p1, &p2, &p3, 40_f64.to_radians()),
+        constraints::PointPointPointAngle::new(p1, p2, p3, 40_f64.to_radians()),
     );
     let angle2 = s.add_constraint(
         &[&constraint_set],
-        constraints::PointPointPointAngle::new(&p2, &p3, &p1, 80_f64.to_radians()),
+        constraints::PointPointPointAngle::new(p2, p3, p1, 80_f64.to_radians()),
     );
     s.solve(
         &element_set,
@@ -33,8 +33,8 @@ fn underconstrained_triangle() {
     );
 
     let sum_squared_residuals = sum_squares(&[
-        s.calculate_constraint_residual(&angle1),
-        s.calculate_constraint_residual(&angle2),
+        s.calculate_constraint_residual(angle1),
+        s.calculate_constraint_residual(angle2),
     ]);
     assert!(
         sum_squared_residuals < RESIDUAL_THRESHOLD,
@@ -53,23 +53,23 @@ fn overconstrained_triangle_line_incidence() {
     let p2 = s.add_element(&[&element_set], elements::Point { x: 1., y: 0.5 });
     let p3 = s.add_element(&[&element_set], elements::Point { x: 2., y: 1. });
     let p4 = s.add_element(&[&element_set], elements::Point { x: 3., y: 1.5 });
-    let line1 = s.add_element(&[&element_set], elements::Line::new(&p3, &p4));
+    let line1 = s.add_element(&[&element_set], elements::Line::new(p3, p4));
     // Overconstrain the triangle angles to something that's geometrically impossible.
     let angle1 = s.add_constraint(
         &[&constraint_set],
-        constraints::PointPointPointAngle::new(&p1, &p2, &p3, 40_f64.to_radians()),
+        constraints::PointPointPointAngle::new(p1, p2, p3, 40_f64.to_radians()),
     );
     let angle2 = s.add_constraint(
         &[&constraint_set],
-        constraints::PointPointPointAngle::new(&p2, &p3, &p1, 80_f64.to_radians()),
+        constraints::PointPointPointAngle::new(p2, p3, p1, 80_f64.to_radians()),
     );
     let angle3 = s.add_constraint(
         &[&constraint_set],
-        constraints::PointPointPointAngle::new(&p3, &p1, &p2, 100_f64.to_radians()),
+        constraints::PointPointPointAngle::new(p3, p1, p2, 100_f64.to_radians()),
     );
     let incidence = s.add_constraint(
         &[&constraint_set],
-        constraints::PointLineIncidence::new(&p2, &line1),
+        constraints::PointLineIncidence::new(p2, line1),
     );
     s.solve(
         &element_set,
@@ -78,16 +78,16 @@ fn overconstrained_triangle_line_incidence() {
     );
 
     let sum_squared_residuals = sum_squares(&[
-        s.calculate_constraint_residual(&angle1),
-        s.calculate_constraint_residual(&angle2),
-        s.calculate_constraint_residual(&angle3),
+        s.calculate_constraint_residual(angle1),
+        s.calculate_constraint_residual(angle2),
+        s.calculate_constraint_residual(angle3),
     ]);
     assert!(
         sum_squared_residuals >= RESIDUAL_THRESHOLD,
         "The angle constraints were unexpectedly solved (this shouldn't be possible geometrically)"
     );
 
-    let squared_incidence_residual = sum_squares(&[s.calculate_constraint_residual(&incidence)]);
+    let squared_incidence_residual = sum_squares(&[s.calculate_constraint_residual(incidence)]);
     assert!(
         squared_incidence_residual < RESIDUAL_THRESHOLD,
         "The point-line incidence was not solved (sum of squared residuals: {sum_squared_residuals})"


### PR DESCRIPTION
`ElementHandles` initially weren't `Clone` and `Copy` to reserve the possibility of doing some fancy ownership around removal of elements from systems, but we're probably not going to be pursuing that. This simplifies the API.

Also derive some utility traits.