### PR TITLE
Add line-line parallelism constraint

### DIFF
--- a/fiksi/src/lib.rs
+++ b/fiksi/src/lib.rs
@@ -78,7 +78,8 @@ use elements::element::ElementId;
 pub use elements::{Element, element::ElementHandle};
 
 use crate::constraints::{
-    LineCircleTangency, LineLineAngle, PointLineIncidence, PointPointDistance, PointPointPointAngle,
+    LineCircleTangency, LineLineAngle, LineLineParallelism, PointLineIncidence, PointPointDistance,
+    PointPointPointAngle,
 };
 
 /// Vertices are the geometric elements of the constraint system.
@@ -96,6 +97,7 @@ pub(crate) enum Edge {
     PointPointPointAngle(PointPointPointAngle),
     PointLineIncidence(PointLineIncidence),
     LineLineAngle(LineLineAngle),
+    LineLineParallelism(LineLineParallelism),
     LineCircleTangency(LineCircleTangency),
 }
 

--- a/fiksi/src/utils.rs
+++ b/fiksi/src/utils.rs
@@ -68,6 +68,15 @@ pub(crate) fn calculate_residuals_and_jacobian(
                         ..(constraint_idx + 1) * num_free_variables],
                 );
             }
+            Edge::LineLineParallelism(constraint) => {
+                constraint.compute_residual_and_partial_derivatives(
+                    free_variable_map,
+                    variables,
+                    &mut residuals[constraint_idx],
+                    &mut jacobian[constraint_idx * num_free_variables
+                        ..(constraint_idx + 1) * num_free_variables],
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
This is similar to the fixed line-line angle constraint (#16), but can be calculated more efficiently by using the property that the 2D cross product of the line vectors must be 0.