### PR TITLE
Call `create` on constraints to add them to the system

### DIFF
--- a/fiksi/README.md
+++ b/fiksi/README.md
@@ -36,29 +36,22 @@ At least one of `std` and `libm` is required; `std` overrides `libm`.
 # Example
 
 ```rust
+use fiksi::{System, constraints, elements};
+
 let mut gcs = fiksi::System::new();
 
 // Add three points, and constrain them into a triangle, such that
 // - one corner has an angle of 10 degrees;
 // - one corner has an angle of 60 degrees; and
 // - the side between those corners is of length 5.
-let p1 = gcs.add_element(fiksi::elements::Point::new(1., 0.));
-let p2 = gcs.add_element(fiksi::elements::Point::new(0.8, 1.));
-let p3 = gcs.add_element(fiksi::elements::Point::new(1.1, 2.));
+let p1 = gcs.add_element(elements::Point::new(1., 0.));
+let p2 = gcs.add_element(elements::Point::new(0.8, 1.));
+let p3 = gcs.add_element(elements::Point::new(1.1, 2.));
 
-gcs.add_constraint(fiksi::constraints::PointPointDistance::new(p2, p3, 5.));
-gcs.add_constraint(fiksi::constraints::PointPointPointAngle::new(
-    p1,
-    p2,
-    p3,
-    10f64.to_radians(),
-));
-gcs.add_constraint(fiksi::constraints::PointPointPointAngle::new(
-    p2,
-    p3,
-    p1,
-    60f64.to_radians(),
-));
+constraints::PointPointDistance::create(&mut gcs, p2, p3, 5.);
+constraints::PointPointPointAngle::create(&mut gcs, p1, p2, p3, 10f64.to_radians());
+constraints::PointPointPointAngle::create(&mut gcs, p2, p3, p1, 60f64.to_radians());
+
 gcs.solve(None, fiksi::SolvingOptions::DEFAULT);
 ```
 

--- a/fiksi/src/tests/basic.rs
+++ b/fiksi/src/tests/basic.rs
@@ -16,18 +16,8 @@ fn underconstrained_triangle() {
     let p1 = s.add_element(elements::Point { x: 0., y: 0. });
     let p2 = s.add_element(elements::Point { x: 1., y: 0.5 });
     let p3 = s.add_element(elements::Point { x: 2., y: 1. });
-    let angle1 = s.add_constraint(constraints::PointPointPointAngle::new(
-        p1,
-        p2,
-        p3,
-        40_f64.to_radians(),
-    ));
-    let angle2 = s.add_constraint(constraints::PointPointPointAngle::new(
-        p2,
-        p3,
-        p1,
-        80_f64.to_radians(),
-    ));
+    let angle1 = constraints::PointPointPointAngle::create(&mut s, p1, p2, p3, 40_f64.to_radians());
+    let angle2 = constraints::PointPointPointAngle::create(&mut s, p2, p3, p1, 80_f64.to_radians());
     s.solve(None, crate::SolvingOptions::default());
 
     let sum_squared_residuals = sum_squares(&[
@@ -51,25 +41,11 @@ fn overconstrained_triangle_line_incidence() {
     let p4 = s.add_element(elements::Point { x: 3., y: 1.5 });
     let line1 = s.add_element(elements::Line::new(p3, p4));
     // Overconstrain the triangle angles to something that's geometrically impossible.
-    let angle1 = s.add_constraint(constraints::PointPointPointAngle::new(
-        p1,
-        p2,
-        p3,
-        40_f64.to_radians(),
-    ));
-    let angle2 = s.add_constraint(constraints::PointPointPointAngle::new(
-        p2,
-        p3,
-        p1,
-        80_f64.to_radians(),
-    ));
-    let angle3 = s.add_constraint(constraints::PointPointPointAngle::new(
-        p3,
-        p1,
-        p2,
-        100_f64.to_radians(),
-    ));
-    let incidence = s.add_constraint(constraints::PointLineIncidence::new(p2, line1));
+    let angle1 = constraints::PointPointPointAngle::create(&mut s, p1, p2, p3, 40_f64.to_radians());
+    let angle2 = constraints::PointPointPointAngle::create(&mut s, p2, p3, p1, 80_f64.to_radians());
+    let angle3 =
+        constraints::PointPointPointAngle::create(&mut s, p3, p1, p2, 100_f64.to_radians());
+    let incidence = constraints::PointLineIncidence::create(&mut s, p2, line1);
     s.solve(None, crate::SolvingOptions::default());
 
     let sum_squared_residuals = sum_squares(&[


### PR DESCRIPTION
This flips the API: rather than constructing a constraint and then adding it to the system, the constraint adds itself to the system and returns a handle to itself.

On main, constraint structs must be constructed first and can only be used for passing to `System::add_constraint` immediately after construction, which is not very useful. This also requires having duplicated structs for constraints, as we want to store information required for performing the calculations inside the structs, not the element handles used to construct them.

As there will potentially be many constraints, an API on the `System` itself, like `System::{constrain_point_point_distance,
constrain_point_line_incidence, ...}`, would probably grow too many methods.

(In this PR, the `Constraint` trait is now mostly vestigial, but may be useful in the future.)