### PR TITLE
Move value getters to element and constraint handles

### DIFF
--- a/fiksi/src/constraints/mod.rs
+++ b/fiksi/src/constraints/mod.rs
@@ -27,6 +27,8 @@ impl FloatExt for f64 {
 pub(crate) mod constraint {
     use core::marker::PhantomData;
 
+    use crate::{System, utils};
+
     /// A handle to a constraint within a [`System`](crate::System).
     pub struct ConstraintHandle<T> {
         /// The ID of the system the constraint belongs to.
@@ -47,6 +49,20 @@ pub(crate) mod constraint {
 
         pub(crate) fn drop_system_id(self) -> ConstraintId {
             ConstraintId { id: self.id }
+        }
+
+        /// Calculate the residual of this constraint.
+        pub fn calculate_residual(self, system: &System) -> f64 {
+            let edge = &system.constraint_edges[self.id as usize];
+            let residual = &mut [0.];
+            utils::calculate_residuals_and_jacobian(
+                &[edge],
+                &alloc::collections::BTreeMap::new(),
+                &system.variables,
+                residual,
+                &mut [],
+            );
+            residual[0]
         }
     }
 

--- a/fiksi/src/elements/mod.rs
+++ b/fiksi/src/elements/mod.rs
@@ -6,6 +6,8 @@
 use alloc::vec::Vec;
 
 pub(crate) mod element {
+    use crate::System;
+
     use super::{Element, sealed::ElementInner};
 
     /// Dynamically tagged, typed handles to elements.
@@ -41,6 +43,21 @@ pub(crate) mod element {
 
         pub(crate) fn drop_system_id(self) -> ElementId {
             ElementId { id: self.id }
+        }
+
+        /// Get the value of the element.
+        pub fn get_value(&self, system: &System) -> <T as Element>::Output {
+            // TODO: return `Result` instead of panicking?
+            assert_eq!(
+                self.system_id, system.id,
+                "Tried to get an element that is not part of this `System`"
+            );
+
+            <T as ElementInner>::from_vertex(
+                &system.element_vertices[self.drop_system_id().id as usize],
+                &system.variables,
+            )
+            .into()
         }
 
         /// Get a type-erased handle to the element.

--- a/fiksi/src/lib.rs
+++ b/fiksi/src/lib.rs
@@ -233,21 +233,6 @@ impl System {
         ElementHandle::from_ids(self.id, id)
     }
 
-    /// Get the value of an element.
-    pub fn get_element<T: Element>(&self, element: ElementHandle<T>) -> <T as Element>::Output {
-        // TODO: return `Result` instead of panicking?
-        assert_eq!(
-            self.id, element.system_id,
-            "Tried to get an element that is not part of this `System`"
-        );
-
-        T::from_vertex(
-            &self.element_vertices[element.drop_system_id().id as usize],
-            &self.variables,
-        )
-        .into()
-    }
-
     /// Iterate over the handles of all elements in the system.
     ///
     /// You can use [`System::get_element`] to get an element-tagged value or
@@ -257,20 +242,6 @@ impl System {
         (0..self.element_vertices.len()).map(|id| {
             ElementHandle::from_ids(self.id, id.try_into().expect("less than 2^32 elements"))
         })
-    }
-
-    /// Calculate the residual of a constraint.
-    pub fn calculate_constraint_residual<T>(&self, constraint: ConstraintHandle<T>) -> f64 {
-        let edge = &self.constraint_edges[constraint.drop_system_id().id as usize];
-        let residual = &mut [0.];
-        utils::calculate_residuals_and_jacobian(
-            &[edge],
-            &alloc::collections::BTreeMap::new(),
-            &self.variables,
-            residual,
-            &mut [],
-        );
-        residual[0]
     }
 
     /// Add a constraint.

--- a/fiksi/src/tests/basic.rs
+++ b/fiksi/src/tests/basic.rs
@@ -20,10 +20,8 @@ fn underconstrained_triangle() {
     let angle2 = constraints::PointPointPointAngle::create(&mut s, p2, p3, p1, 80_f64.to_radians());
     s.solve(None, crate::SolvingOptions::default());
 
-    let sum_squared_residuals = sum_squares(&[
-        s.calculate_constraint_residual(angle1),
-        s.calculate_constraint_residual(angle2),
-    ]);
+    let sum_squared_residuals =
+        sum_squares(&[angle1.calculate_residual(&s), angle2.calculate_residual(&s)]);
     assert!(
         sum_squared_residuals < RESIDUAL_THRESHOLD,
         "The system was not solved (sum of squared residuals: {sum_squared_residuals})"
@@ -49,16 +47,16 @@ fn overconstrained_triangle_line_incidence() {
     s.solve(None, crate::SolvingOptions::default());
 
     let sum_squared_residuals = sum_squares(&[
-        s.calculate_constraint_residual(angle1),
-        s.calculate_constraint_residual(angle2),
-        s.calculate_constraint_residual(angle3),
+        angle1.calculate_residual(&s),
+        angle2.calculate_residual(&s),
+        angle3.calculate_residual(&s),
     ]);
     assert!(
         sum_squared_residuals >= RESIDUAL_THRESHOLD,
         "The angle constraints were unexpectedly solved (this shouldn't be possible geometrically)"
     );
 
-    let squared_incidence_residual = sum_squares(&[s.calculate_constraint_residual(incidence)]);
+    let squared_incidence_residual = sum_squares(&[incidence.calculate_residual(&s)]);
     assert!(
         squared_incidence_residual < RESIDUAL_THRESHOLD,
         "The point-line incidence was not solved (sum of squared residuals: {sum_squared_residuals})"


### PR DESCRIPTION
This makes the handles more generally useful, and aligns the signatures of constraint creation and using handles.