### PR TITLE
Add `Graph` to track structure of the system

### DIFF
--- a/fiksi/src/constraints/mod.rs
+++ b/fiksi/src/constraints/mod.rs
@@ -6,7 +6,10 @@
 #[cfg(not(feature = "std"))]
 use crate::floatfuncs::FloatFuncs;
 
-use crate::{ConstraintHandle, Edge, ElementHandle, Subsystem, System, Vertex, elements};
+use crate::{
+    ConstraintHandle, Edge, ElementHandle, Subsystem, System, Vertex, elements,
+    graph::IncidentElements,
+};
 
 trait FloatExt {
     /// Returns the square of `self`.
@@ -292,6 +295,10 @@ impl PointPointDistance {
             distance,
         };
 
+        system.graph.add_constraint(
+            1,
+            IncidentElements::from_array([point1.drop_system_id(), point2.drop_system_id()]),
+        );
         system.add_constraint(Edge::PointPointDistance(constraint))
     }
 
@@ -384,6 +391,14 @@ impl PointPointPointAngle {
             angle,
         };
 
+        system.graph.add_constraint(
+            1,
+            IncidentElements::from_array([
+                point1.drop_system_id(),
+                point2.drop_system_id(),
+                point3.drop_system_id(),
+            ]),
+        );
         system.add_constraint(Edge::PointPointPointAngle(constraint))
     }
 
@@ -504,6 +519,14 @@ impl PointLineIncidence {
             line_point2_idx,
         };
 
+        system.graph.add_constraint(
+            1,
+            IncidentElements::from_array([
+                point.drop_system_id(),
+                system.variable_to_primitive[line_point1_idx as usize],
+                system.variable_to_primitive[line_point2_idx as usize],
+            ]),
+        );
         system.add_constraint(Edge::PointLineIncidence(constraint))
     }
 
@@ -610,6 +633,15 @@ impl LineLineAngle {
             angle,
         };
 
+        system.graph.add_constraint(
+            1,
+            IncidentElements::from_array([
+                system.variable_to_primitive[line1_point1_idx as usize],
+                system.variable_to_primitive[line1_point2_idx as usize],
+                system.variable_to_primitive[line2_point1_idx as usize],
+                system.variable_to_primitive[line2_point2_idx as usize],
+            ]),
+        );
         system.add_constraint(Edge::LineLineAngle(constraint))
     }
 
@@ -732,6 +764,16 @@ impl LineLineParallelism {
         else {
             unreachable!()
         };
+
+        system.graph.add_constraint(
+            1,
+            IncidentElements::from_array([
+                system.variable_to_primitive[line1_point1_idx as usize],
+                system.variable_to_primitive[line1_point2_idx as usize],
+                system.variable_to_primitive[line2_point1_idx as usize],
+                system.variable_to_primitive[line2_point2_idx as usize],
+            ]),
+        );
         system.add_constraint(Edge::LineLineParallelism(Self {
             line1_point1_idx,
             line1_point2_idx,
@@ -851,6 +893,15 @@ impl LineCircleTangency {
             circle_radius_idx,
         };
 
+        system.graph.add_constraint(
+            1,
+            IncidentElements::from_array([
+                system.variable_to_primitive[line_point1_idx as usize],
+                system.variable_to_primitive[line_point2_idx as usize],
+                system.variable_to_primitive[circle_center_idx as usize],
+                circle.drop_system_id(),
+            ]),
+        );
         system.add_constraint(Edge::LineCircleTangency(constraint))
     }
 

--- a/fiksi/src/elements/mod.rs
+++ b/fiksi/src/elements/mod.rs
@@ -222,7 +222,9 @@ impl Point {
     /// Construct a new `Point` at the given coordinate.
     pub fn create(system: &mut System, x: f64, y: f64) -> ElementHandle<Self> {
         let idx = system.add_variables([x, y]);
-        system.add_element(Vertex::Point { idx })
+        let handle = system.add_element(Vertex::Point { idx }, 2);
+        system.assign_variable_primitive::<2>(handle.drop_system_id());
+        handle
     }
 }
 
@@ -269,10 +271,13 @@ impl Line {
         else {
             unreachable!()
         };
-        system.add_element(Vertex::Line {
-            point1_idx,
-            point2_idx,
-        })
+        system.add_element(
+            Vertex::Line {
+                point1_idx,
+                point2_idx,
+            },
+            0,
+        )
     }
 }
 
@@ -327,10 +332,15 @@ impl Circle {
             unreachable!()
         };
         let radius_idx = system.add_variables([radius]);
-        system.add_element(Vertex::Circle {
-            center_idx,
-            radius_idx,
-        })
+        let handle = system.add_element(
+            Vertex::Circle {
+                center_idx,
+                radius_idx,
+            },
+            1,
+        );
+        system.assign_variable_primitive::<1>(handle.drop_system_id());
+        handle
     }
 }
 

--- a/fiksi/src/graph.rs
+++ b/fiksi/src/graph.rs
@@ -1,0 +1,236 @@
+// Copyright 2025 the Fiksi Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use core::num::NonZeroU32;
+
+use alloc::{
+    collections::BTreeSet,
+    {vec, vec::Vec},
+};
+
+use crate::{ConstraintId, elements::element::ElementId};
+
+type IncidentConstraints = Vec<ConstraintId>;
+
+/// The elements incident to a constraint.
+///
+/// Currently there are never more than six elements in a constraint, though that may change in the
+/// future. For now, it's small enough to store on the stack.
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct IncidentElements {
+    len: u8,
+    elements: [ElementId; 6],
+}
+
+impl IncidentElements {
+    #[inline(always)]
+    pub(crate) const fn from_array<const LEN: usize>(elements: [ElementId; LEN]) -> Self {
+        const {
+            if LEN < 2 || LEN > 6 {
+                panic!("`N` must be between 2 and 6 (both inclusive)");
+            }
+        }
+
+        let mut self_elements = [ElementId { id: 0 }; 6];
+        let mut idx = 0;
+        while idx < LEN {
+            self_elements[idx] = elements[idx];
+            idx += 1;
+        }
+        Self {
+            len: LEN as u8,
+            elements: self_elements,
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) const fn len(&self) -> usize {
+        self.len as usize
+    }
+
+    #[inline(always)]
+    pub(crate) fn as_slice(&self) -> &[ElementId] {
+        &self.elements[..self.len()]
+    }
+
+    /// Merge multiple elements in this constraint into a single cluster element given by `into`.
+    ///
+    /// `merge_predicate` should return `false` for at least one of the elements in `self`, to
+    /// ensure the new constraint connects at least two elements.
+    #[inline(always)]
+    pub(crate) fn merge_elements(
+        &self,
+        merge_predicate: impl Fn(ElementId) -> bool,
+        into: ElementId,
+    ) -> Self {
+        let mut elements = [ElementId { id: 0 }; 6];
+        let mut len = 0;
+        let mut folded = false;
+
+        for &element in self.as_slice() {
+            if merge_predicate(element) {
+                if !folded {
+                    elements[len] = into;
+                    len += 1;
+                    folded = true;
+                }
+            } else {
+                elements[len] = element;
+                len += 1;
+            }
+        }
+
+        Self {
+            len: len as u8,
+            elements,
+        }
+    }
+}
+
+/// A primitive geometric element.
+#[derive(Clone)]
+pub(crate) struct Element {
+    /// The degrees of freedom of the element.
+    pub(crate) dof: i16,
+
+    /// The constraints acting on this element.
+    pub(crate) incident_constraints: IncidentConstraints,
+}
+
+/// A constraint between elements.
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct Constraint {
+    /// The valency of the constraint (in other words, the degrees of freedom taken away by this
+    /// constraint).
+    pub(crate) valency: i16,
+
+    /// The elements this constraint acts on.
+    pub(crate) incident_elements: IncidentElements,
+}
+
+/// A graph tracking the structure of a geometric constraint system.
+///
+/// This tracks (primitive) geometric elements and constraints between them, as well as degrees of
+/// freedom of elements and the degrees of freedom consumed by constraints.
+///
+/// Elements are kept organized in separate connected components.
+#[derive(Clone)]
+pub(crate) struct Graph {
+    pub(crate) elements: Vec<Element>,
+    pub(crate) constraints: Vec<Constraint>,
+
+    /// The map from elements to connected components.
+    ///
+    /// The value for an element is `None` iff it is not part of any connected components (i.e., no
+    /// constraints connect the element with another element).
+    pub(crate) element_connected_component: Vec<Option<NonZeroU32>>,
+    pub(crate) connected_components: Vec<BTreeSet<ElementId>>,
+}
+
+impl Graph {
+    pub(crate) fn new() -> Self {
+        Self {
+            elements: vec![],
+            constraints: vec![],
+            element_connected_component: vec![],
+            connected_components: vec![],
+        }
+    }
+
+    pub(crate) fn add_element(&mut self, dof: i16) -> ElementId {
+        debug_assert!(
+            dof >= 0,
+            "Elements should have non-negative degrees of freedom"
+        );
+
+        let element = ElementId {
+            id: self.elements.len().try_into().unwrap(),
+        };
+        self.elements.push(Element {
+            dof,
+            incident_constraints: IncidentConstraints::new(),
+        });
+        self.element_connected_component.push(None);
+
+        element
+    }
+
+    fn merge_connected_components(&mut self, elements: &[ElementId]) {
+        // Find the largest connected component to merge the others in to.
+        let target_component_idx = {
+            let mut target_component = None;
+            let mut size_largest = 0;
+            for element in elements {
+                if let Some(component_idx) = self.element_connected_component[element.id as usize] {
+                    let component = &self.connected_components[component_idx.get() as usize - 1];
+                    if component.len() > size_largest {
+                        target_component = Some(component_idx);
+                        size_largest = component.len();
+                    }
+                }
+            }
+
+            if target_component.is_none() {
+                self.connected_components.push(BTreeSet::new());
+                target_component = Some(
+                    u32::try_from(self.connected_components.len())
+                        .unwrap()
+                        .try_into()
+                        .unwrap(),
+                );
+            }
+            target_component.unwrap()
+        };
+
+        let mut target_component = core::mem::take(
+            &mut self.connected_components[target_component_idx.get() as usize - 1],
+        );
+
+        // Merge all elements' components into the target component, and set their component index.
+        for element in elements {
+            if let Some(component_idx) = self.element_connected_component[element.id as usize] {
+                let component = core::mem::take(
+                    &mut self.connected_components[component_idx.get() as usize - 1],
+                );
+                target_component.extend(&component);
+            } else {
+                target_component.insert(*element);
+            }
+            self.element_connected_component[element.id as usize] = Some(target_component_idx);
+        }
+        self.connected_components[target_component_idx.get() as usize - 1] = target_component;
+    }
+
+    fn push_incident_constraint(&mut self, elements: &[ElementId], constraint: ConstraintId) {
+        for element in elements {
+            self.elements[element.id as usize]
+                .incident_constraints
+                .push(constraint);
+        }
+    }
+
+    pub(crate) fn add_constraint(
+        &mut self,
+        valency: i16,
+        incident_elements: IncidentElements,
+    ) -> ConstraintId {
+        debug_assert!(valency >= 0, "Constraints should have non-negative valency");
+
+        let constraint = ConstraintId {
+            id: self.constraints.len().try_into().unwrap(),
+        };
+
+        self.merge_connected_components(incident_elements.as_slice());
+        self.push_incident_constraint(incident_elements.as_slice(), constraint);
+        self.constraints.push(Constraint {
+            valency,
+            incident_elements,
+        });
+
+        constraint
+    }
+
+    pub(crate) fn connected_components(&self) -> &[BTreeSet<ElementId>] {
+        &self.connected_components
+    }
+}

--- a/fiksi/src/graph.rs
+++ b/fiksi/src/graph.rs
@@ -10,8 +10,6 @@ use alloc::{
 
 use crate::{ConstraintId, elements::element::ElementId};
 
-type IncidentConstraints = Vec<ConstraintId>;
-
 /// The elements incident to a constraint.
 ///
 /// Currently there are never more than six elements in a constraint, though that may change in the
@@ -102,7 +100,7 @@ pub(crate) struct Element {
     pub(crate) dof: i16,
 
     /// The constraints acting on this element.
-    pub(crate) incident_constraints: IncidentConstraints,
+    pub(crate) incident_constraints: Vec<ConstraintId>,
 }
 
 /// A constraint between elements.
@@ -156,7 +154,7 @@ impl Graph {
         };
         self.elements.push(Element {
             dof,
-            incident_constraints: IncidentConstraints::new(),
+            incident_constraints: vec![],
         });
         self.element_connected_component.push(None);
 

--- a/fiksi/src/graph.rs
+++ b/fiksi/src/graph.rs
@@ -24,6 +24,10 @@ pub(crate) struct IncidentElements {
 
 impl IncidentElements {
     #[inline(always)]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "the const panic ensures this never truncates"
+    )]
     pub(crate) const fn from_array<const LEN: usize>(elements: [ElementId; LEN]) -> Self {
         const {
             if LEN < 2 || LEN > 6 {
@@ -80,6 +84,10 @@ impl IncidentElements {
             }
         }
 
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "`len` is always equal to or less than the `self.len`, so this never truncates"
+        )]
         Self {
             len: len as u8,
             elements,

--- a/fiksi/src/graph.rs
+++ b/fiksi/src/graph.rs
@@ -67,14 +67,14 @@ impl IncidentElements {
     ) -> Self {
         let mut elements = [ElementId { id: 0 }; 6];
         let mut len = 0;
-        let mut folded = false;
+        let mut merged = false;
 
         for &element in self.as_slice() {
             if merge_predicate(element) {
-                if !folded {
+                if !merged {
                     elements[len] = into;
                     len += 1;
-                    folded = true;
+                    merged = true;
                 }
             } else {
                 elements[len] = element;


### PR DESCRIPTION
This keeps track of connected components online (to know which parts of the system are completely distinct and can trivially be solved and analyzed separately). The graph also tracks the degrees of freedom of the elements and valency of constraints. That information is not used here yet, but will be soon.

The tracking is based on the element primitives. For example, a line consists of exactly two point primitives, and nothing more. A circle consists of a point primitive and a radius. That means a line-line parallelism constraint, say, adds a hyperedge between four point primitives.