### PR TITLE
Implement `Hash` for handles

### DIFF
--- a/fiksi/src/constraints/mod.rs
+++ b/fiksi/src/constraints/mod.rs
@@ -206,6 +206,13 @@ pub(crate) mod constraint {
         }
     }
 
+    impl<T> core::hash::Hash for ConstraintHandle<T> {
+        fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+            self.system_id.hash(state);
+            self.id.hash(state);
+        }
+    }
+
     impl PartialEq for AnyConstraintHandle {
         fn eq(&self, other: &Self) -> bool {
             // Constraint handle IDs are unique, so we don't need to compare the tags.
@@ -223,6 +230,14 @@ pub(crate) mod constraint {
     impl PartialOrd for AnyConstraintHandle {
         fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
             Some(self.cmp(other))
+        }
+    }
+
+    impl core::hash::Hash for AnyConstraintHandle {
+        fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+            // Constraint handle IDs are unique, so we don't need to hash the tags.
+            self.system_id.hash(state);
+            self.id.hash(state);
         }
     }
 

--- a/fiksi/src/elements/mod.rs
+++ b/fiksi/src/elements/mod.rs
@@ -157,6 +157,13 @@ pub(crate) mod element {
         }
     }
 
+    impl<T: Element> core::hash::Hash for ElementHandle<T> {
+        fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+            self.system_id.hash(state);
+            self.id.hash(state);
+        }
+    }
+
     impl PartialEq for AnyElementHandle {
         fn eq(&self, other: &Self) -> bool {
             // Element handle IDs are unique, so we don't need to compare the tags.
@@ -174,6 +181,14 @@ pub(crate) mod element {
     impl PartialOrd for AnyElementHandle {
         fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
             Some(self.cmp(other))
+        }
+    }
+
+    impl core::hash::Hash for AnyElementHandle {
+        fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+            // Element handle IDs are unique, so we don't need to hash the tags.
+            self.system_id.hash(state);
+            self.id.hash(state);
         }
     }
 


### PR DESCRIPTION
This is useful for, e.g., users wanting to put handles into a map (like the currently-only-on-my-machine SVG renderer does).