### PR TITLE
Rename entities in tests to be zero-indexed

### DIFF
--- a/fiksi/src/tests/triangles.rs
+++ b/fiksi/src/tests/triangles.rs
@@ -7,23 +7,23 @@ use crate::{System, constraints, elements, utils::sum_squares};
 fn connected_triangles() {
     let mut s = System::new();
 
-    let p1 = elements::Point::create(&mut s, 0., 0.);
-    let p2 = elements::Point::create(&mut s, 1., 0.5);
-    let p3 = elements::Point::create(&mut s, 2., 1.);
-    let p4 = elements::Point::create(&mut s, 3., 1.5);
-    let p5 = elements::Point::create(&mut s, 4., 2.);
-    let p6 = elements::Point::create(&mut s, 5., 2.5);
+    let p0 = elements::Point::create(&mut s, 0., 0.);
+    let p1 = elements::Point::create(&mut s, 1., 0.5);
+    let p2 = elements::Point::create(&mut s, 2., 1.);
+    let p3 = elements::Point::create(&mut s, 3., 1.5);
+    let p4 = elements::Point::create(&mut s, 4., 2.);
+    let p5 = elements::Point::create(&mut s, 5., 2.5);
 
-    constraints::PointPointPointAngle::create(&mut s, p6, p1, p2, -135_f64.to_radians());
-    constraints::PointPointPointAngle::create(&mut s, p2, p3, p4, -120_f64.to_radians());
-    constraints::PointPointPointAngle::create(&mut s, p4, p5, p6, -115_f64.to_radians());
+    constraints::PointPointPointAngle::create(&mut s, p5, p0, p1, -135_f64.to_radians());
+    constraints::PointPointPointAngle::create(&mut s, p1, p2, p3, -120_f64.to_radians());
+    constraints::PointPointPointAngle::create(&mut s, p3, p4, p5, -115_f64.to_radians());
 
-    constraints::PointPointDistance::create(&mut s, p1, p2, 7.);
-    constraints::PointPointDistance::create(&mut s, p2, p3, 5.);
-    constraints::PointPointDistance::create(&mut s, p3, p4, 9.);
-    constraints::PointPointDistance::create(&mut s, p4, p5, 8.);
-    constraints::PointPointDistance::create(&mut s, p5, p6, 6.);
-    constraints::PointPointDistance::create(&mut s, p6, p1, 7.);
+    constraints::PointPointDistance::create(&mut s, p0, p1, 7.);
+    constraints::PointPointDistance::create(&mut s, p1, p2, 5.);
+    constraints::PointPointDistance::create(&mut s, p2, p3, 9.);
+    constraints::PointPointDistance::create(&mut s, p3, p4, 8.);
+    constraints::PointPointDistance::create(&mut s, p4, p5, 6.);
+    constraints::PointPointDistance::create(&mut s, p5, p0, 7.);
 
     s.solve(None, crate::SolvingOptions::default());
 


### PR DESCRIPTION
As internal IDs are zero-indexed, this makes it simpler to match the names with internal IDs.