### PR TITLE
Fix final subgraph that gets returned by decomposition

### DIFF
--- a/fiksi/src/analyze/graph/mod.rs
+++ b/fiksi/src/analyze/graph/mod.rs
@@ -91,9 +91,13 @@ pub(crate) fn decompose<const D: i16>(
     vertices: impl Iterator<Item = ElementId>,
     edges: impl Iterator<Item = ConstraintId>,
 ) -> RecombinationPlan {
-    // This is the number of real constraints in the system. More "merged" constraints will be
-    // added as part of rigidity bookkeeping in this algorithm, but these don't need to be
-    // solved again.
+    // These are the number of real constraints and elements in the system. More "merged"
+    // constraints and elements will be added as part of rigidity bookkeeping in this algorithm,
+    // but the entities they're made of don't need to be solved again.
+    //
+    // Currently, the constraint and elements IDs are just indices into the vectors, meaning that
+    // the IDs can be compared against these lengths to determine whether the constraint or element
+    // is "real," or is a merged entity used for bookkeeping.
     let num_real_constraints = u32::try_from(graph.constraints.len()).unwrap();
     let num_real_elements = u32::try_from(graph.elements.len()).unwrap();
 


### PR DESCRIPTION
It could contain constraints that were only used for bookkeeping.

(We still want to do something smarter here than in this PR, but the implementation on main is buggy.)