### PR TITLE
Improve Levenberg-Marquardt steps and `lambda` schedule

### DIFF
--- a/fiksi/src/solve/lm.rs
+++ b/fiksi/src/solve/lm.rs
@@ -19,37 +19,35 @@ pub(crate) fn levenberg_marquardt(variables: &mut [f64], subsystem: &Subsystem<'
     // TODO: this is allocation-happy.
     // TODO: we don't use enough of nalgebra here to justify including that dependency.
 
-    let mut lambda = 10.;
-    let mut prev_residual = f64::INFINITY;
+    let mut variables_scratch = variables.to_vec();
+    let variables_scratch = variables_scratch.as_mut_slice();
 
     // The (non-squared) residuals of the constraints.
-    let mut residuals = vec![0.; subsystem.constraints().len()];
+    let mut residuals = nalgebra::DVector::zeros(subsystem.constraints().len());
+    let mut residuals_scratch = nalgebra::DVector::zeros(subsystem.constraints().len());
+
     // All first-order partial derivatives of the constraints. This is a dense representation (each
     // pair of constraint and variable has a partial derivative represented here, even for
     // variables that do not contribute to the constraint). It's possible a sparse representation
     // may be more efficient in certain cases.
     let mut jacobian = vec![0.; subsystem.constraints().len() * subsystem.free_variables().len()];
+    let mut jacobian_scratch =
+        vec![0.; subsystem.constraints().len() * subsystem.free_variables().len()];
 
-    for _ in 0..100 {
-        calculate_residuals_and_jacobian(subsystem, variables, &mut residuals, &mut jacobian);
+    calculate_residuals_and_jacobian(
+        subsystem,
+        variables,
+        residuals.as_mut_slice(),
+        &mut jacobian,
+    );
 
-        let residuals_ = nalgebra::DVector::from_column_slice(&residuals);
-        let residual = residuals_.norm();
+    let mut residual = residuals.norm();
 
-        // TODO: revisit stopping conditions and the `lambda` schedule.
+    let mut lambda = 0.5;
+    'steps: for _ in 0..100 {
         if residual < 1e-4 {
             break;
         }
-
-        if residual < prev_residual {
-            lambda *= 0.5;
-            if lambda < 1e-50 {
-                lambda = 1e-50;
-            }
-        } else {
-            lambda *= 2.;
-        }
-        prev_residual = residual;
 
         // Clone the Jacobian to a nalgebra matrix for now.
         // TODO: remove
@@ -63,54 +61,83 @@ pub(crate) fn levenberg_marquardt(variables: &mut [f64], subsystem: &Subsystem<'
             }
         }
 
-        // Levenberg-Marquardt requires solving (J^T J + λ I) δ = J^T r(x) for δ, where r is the
-        // vector-valued residual function, J is the Jacobian of r, λ is the damping factor, I is
-        // the identity matrix, and δ is the update step of the variables.
-        //
-        // Here, these calculations are performed with finite precision using floating points. The
-        // numerical imprecision expected in δ (the "condition number" of (J^T J)) is the square of
-        // the condition number of J. In other words, the effect of order of magnitude differences
-        // is doubled.
-        //
-        // Instead of solving for the above expression, we can equivalently solve for the
-        // augmented matrices:
-        // [  J        ]     [ r ]
-        // [ sqrt(λ) I ] δ = [ 0 ]
-        // using QR-decomposition, see e.g, Equation 3.2 of "The Levenberg-Marquardt algorithm:
-        // implementations and theory" by J. J. Moré (1997).
-        //
-        // This is slower per computation and therefore slower in the well-conditioned case, but it
-        // is numerically more stable as we don't form the square of the Jacobian. In numerically
-        // ill-conditioned cases, the lack of stability due to forming the square can lead to
-        // having to perform many more iterations to converge, as well as failure to convergence at
-        // all.
-        let mut j_aug =
-            nalgebra::DMatrix::zeros(jacobian_.nrows() + jacobian_.ncols(), jacobian_.ncols());
-        j_aug.rows_mut(0, jacobian_.nrows()).copy_from(&jacobian_);
-        // Augment by the damping factor `lambda`.
-        for idx in 0..jacobian_.ncols() {
-            j_aug[(jacobian_.nrows() + idx, idx)] += f64::sqrt(lambda);
-        }
-        // The augmented residual matrix:
-        // [ r ]
-        // [ 0 ]
-        let mut r_aug = nalgebra::DMatrix::zeros(jacobian_.nrows() + jacobian_.ncols(), 1);
-        r_aug.rows_mut(0, jacobian_.nrows()).copy_from(&residuals_);
+        // Inner loop to find a suitable damping factor allowing a step to be accepted.
+        loop {
+            // Levenberg-Marquardt requires solving (J^T J + λ I) δ = J^T r(x) for δ, where r is the
+            // vector-valued residual function, J is the Jacobian of r, λ is the damping factor, I is
+            // the identity matrix, and δ is the update step of the variables.
+            //
+            // Here, these calculations are performed with finite precision using floating points. The
+            // numerical imprecision expected in δ (the "condition number" of (J^T J)) is the square of
+            // the condition number of J. In other words, the effect of order of magnitude differences
+            // is doubled.
+            //
+            // Instead of solving for the above expression, we can equivalently solve for the
+            // augmented matrices:
+            // [  J        ]     [ r ]
+            // [ sqrt(λ) I ] δ = [ 0 ]
+            // using QR-decomposition, see e.g, Equation 3.2 of "The Levenberg-Marquardt algorithm:
+            // implementations and theory" by J. J. Moré (1997).
+            //
+            // This is slower per computation and therefore slower in the well-conditioned case, but it
+            // is numerically more stable as we don't form the square of the Jacobian. In numerically
+            // ill-conditioned cases, the lack of stability due to forming the square can lead to
+            // having to perform many more iterations to converge, as well as failure to convergence at
+            // all.
+            let mut j_aug =
+                nalgebra::DMatrix::zeros(jacobian_.nrows() + jacobian_.ncols(), jacobian_.ncols());
+            j_aug.rows_mut(0, jacobian_.nrows()).copy_from(&jacobian_);
+            // Augment by the damping factor `lambda`.
+            for idx in 0..jacobian_.ncols() {
+                j_aug[(jacobian_.nrows() + idx, idx)] += f64::sqrt(lambda);
+            }
+            // The augmented residual matrix:
+            // [ r ]
+            // [ 0 ]
+            let mut r_aug = nalgebra::DMatrix::zeros(jacobian_.nrows() + jacobian_.ncols(), 1);
+            r_aug.rows_mut(0, jacobian_.nrows()).copy_from(&residuals);
 
-        let qr = j_aug.col_piv_qr();
-        if let Some(mut delta) = qr
-            .r()
-            .solve_upper_triangular(&(-qr.q().transpose() * r_aug))
-        {
+            let qr = j_aug.col_piv_qr();
+            let Some(mut delta) = qr
+                .r()
+                .solve_upper_triangular(&(-qr.q().transpose() * r_aug))
+            else {
+                lambda *= 8.;
+                continue;
+            };
+
             qr.p().inv_permute_rows(&mut delta);
             if delta.norm() < 1e-6 {
-                break;
+                break 'steps;
             }
+
             for (idx, variable) in subsystem.free_variables().enumerate() {
-                variables[variable as usize] += delta[idx];
+                variables_scratch[variable as usize] = variables[variable as usize] + delta[idx];
             }
-        } else {
-            panic!("Levenberg-Marquardt: failed to solve linear system");
+
+            calculate_residuals_and_jacobian(
+                subsystem,
+                variables_scratch,
+                residuals_scratch.as_mut_slice(),
+                &mut jacobian_scratch,
+            );
+            let residual_scratch = residuals_scratch.norm();
+
+            if residual_scratch < residual {
+                // Accept step
+                lambda *= 0.125;
+                if lambda < 1e-50 {
+                    lambda = 1e-50;
+                }
+                residual = residual_scratch;
+                variables.copy_from_slice(variables_scratch);
+                core::mem::swap(&mut jacobian, &mut jacobian_scratch);
+                core::mem::swap(&mut residuals, &mut residuals_scratch);
+                break;
+            } else {
+                // Reject step.
+                lambda *= 2.;
+            }
         }
     }
 }


### PR DESCRIPTION
Step acceptance is introduced such that steps are only taken when they decrease the residual, updating `lambda` until a suitable step is found. In some cases taking controlled, uphill steps can be useful to navigate long valleys, I have some local changes experimenting with that. On current main (and https://github.com/endoli/fiksi/pull/48) uphill steps are taken in an uncontrolled manner.