### PR TITLE
Speed up LM step finding by not requiring Jacobian calculation

### DIFF
--- a/fiksi/src/constraints/mod.rs
+++ b/fiksi/src/constraints/mod.rs
@@ -302,6 +302,12 @@ impl PointPointDistance {
         system.add_constraint(Edge::PointPointDistance(constraint))
     }
 
+    /// If only, say, the residual or some subset of the gradient entries are actually used, and
+    /// that is clear from the code at the call site, the compiler should be able to correctly
+    /// remove the dead calculations as this is marked as `#[inline(always)]`. That allows us not to
+    /// to duplicate code unnecessarily for the calculations. Plus, calculating the residuals and
+    /// the Jacobian at the same time is a common case, and for some constraints it's more efficient
+    /// when they're calculated together.
     #[inline(always)]
     fn compute_residual_and_gradient_(
         variables: &[f64; 4],
@@ -331,6 +337,8 @@ impl PointPointDistance {
     }
 
     pub(crate) fn compute_residual(&self, variables: &[f64]) -> f64 {
+        // The compiler should be able to optimize this such that only the residual is calculated.
+        // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
         Self::compute_residual_and_gradient_(
             &[
                 variables[self.point1_idx as usize],
@@ -435,6 +443,7 @@ impl PointPointPointAngle {
         system.add_constraint(Edge::PointPointPointAngle(constraint))
     }
 
+    // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
     #[inline(always)]
     fn compute_residual_and_gradient_(variables: &[f64; 6], param_angle: f64) -> (f64, [f64; 6]) {
         let point1 = kurbo::Point {
@@ -488,6 +497,8 @@ impl PointPointPointAngle {
     }
 
     pub(crate) fn compute_residual(&self, variables: &[f64]) -> f64 {
+        // The compiler should be able to optimize this such that only the residual is calculated.
+        // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
         Self::compute_residual_and_gradient_(
             &[
                 variables[self.point1_idx as usize],
@@ -597,6 +608,7 @@ impl PointLineIncidence {
         system.add_constraint(Edge::PointLineIncidence(constraint))
     }
 
+    // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
     #[inline(always)]
     fn compute_residual_and_gradient_(variables: &[f64; 6]) -> (f64, [f64; 6]) {
         let point1 = kurbo::Point {
@@ -630,6 +642,8 @@ impl PointLineIncidence {
     }
 
     pub(crate) fn compute_residual(&self, variables: &[f64]) -> f64 {
+        // The compiler should be able to optimize this such that only the residual is calculated.
+        // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
         Self::compute_residual_and_gradient_(&[
             variables[self.point_idx as usize],
             variables[self.point_idx as usize + 1],
@@ -740,6 +754,7 @@ impl LineLineAngle {
         system.add_constraint(Edge::LineLineAngle(constraint))
     }
 
+    // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
     #[inline(always)]
     fn compute_residual_and_gradient_(variables: &[f64; 8], param_angle: f64) -> (f64, [f64; 8]) {
         let line1_point1 = kurbo::Point {
@@ -796,6 +811,8 @@ impl LineLineAngle {
     }
 
     pub(crate) fn compute_residual(&self, variables: &[f64]) -> f64 {
+        // The compiler should be able to optimize this such that only the residual is calculated.
+        // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
         Self::compute_residual_and_gradient_(
             &[
                 variables[self.line1_point1_idx as usize],
@@ -915,6 +932,7 @@ impl LineLineParallelism {
         }))
     }
 
+    // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
     #[inline(always)]
     fn compute_residual_and_gradient_(variables: &[f64; 8]) -> (f64, [f64; 8]) {
         let line1_point1 = kurbo::Point {
@@ -954,6 +972,8 @@ impl LineLineParallelism {
     }
 
     pub(crate) fn compute_residual(&self, variables: &[f64]) -> f64 {
+        // The compiler should be able to optimize this such that only the residual is calculated.
+        // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
         Self::compute_residual_and_gradient_(&[
             variables[self.line1_point1_idx as usize],
             variables[self.line1_point1_idx as usize + 1],
@@ -1070,6 +1090,7 @@ impl LineCircleTangency {
         system.add_constraint(Edge::LineCircleTangency(constraint))
     }
 
+    // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
     #[inline(always)]
     fn compute_residual_and_gradient_(variables: &[f64; 7]) -> (f64, [f64; 7]) {
         let line_point1 = kurbo::Point {
@@ -1128,6 +1149,8 @@ impl LineCircleTangency {
     }
 
     pub(crate) fn compute_residual(&self, variables: &[f64]) -> f64 {
+        // The compiler should be able to optimize this such that only the residual is calculated.
+        // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
         Self::compute_residual_and_gradient_(&[
             variables[self.line_point1_idx as usize],
             variables[self.line_point1_idx as usize + 1],

--- a/fiksi/src/constraints/mod.rs
+++ b/fiksi/src/constraints/mod.rs
@@ -330,6 +330,19 @@ impl PointPointDistance {
         (residual, gradient)
     }
 
+    pub(crate) fn compute_residual(&self, variables: &[f64]) -> f64 {
+        Self::compute_residual_and_gradient_(
+            &[
+                variables[self.point1_idx as usize],
+                variables[self.point1_idx as usize + 1],
+                variables[self.point2_idx as usize],
+                variables[self.point2_idx as usize + 1],
+            ],
+            self.distance,
+        )
+        .0
+    }
+
     pub(crate) fn compute_residual_and_gradient(
         &self,
         subsystem: &Subsystem<'_>,
@@ -474,6 +487,21 @@ impl PointPointPointAngle {
         (residual, gradient)
     }
 
+    pub(crate) fn compute_residual(&self, variables: &[f64]) -> f64 {
+        Self::compute_residual_and_gradient_(
+            &[
+                variables[self.point1_idx as usize],
+                variables[self.point1_idx as usize + 1],
+                variables[self.point2_idx as usize],
+                variables[self.point2_idx as usize + 1],
+                variables[self.point3_idx as usize],
+                variables[self.point3_idx as usize + 1],
+            ],
+            self.angle,
+        )
+        .0
+    }
+
     pub(crate) fn compute_residual_and_gradient(
         &self,
         subsystem: &Subsystem<'_>,
@@ -569,6 +597,7 @@ impl PointLineIncidence {
         system.add_constraint(Edge::PointLineIncidence(constraint))
     }
 
+    #[inline(always)]
     fn compute_residual_and_gradient_(variables: &[f64; 6]) -> (f64, [f64; 6]) {
         let point1 = kurbo::Point {
             x: variables[0],
@@ -598,6 +627,18 @@ impl PointLineIncidence {
         ];
 
         (residual, gradient)
+    }
+
+    pub(crate) fn compute_residual(&self, variables: &[f64]) -> f64 {
+        Self::compute_residual_and_gradient_(&[
+            variables[self.point_idx as usize],
+            variables[self.point_idx as usize + 1],
+            variables[self.line_point1_idx as usize],
+            variables[self.line_point1_idx as usize + 1],
+            variables[self.line_point2_idx as usize],
+            variables[self.line_point2_idx as usize + 1],
+        ])
+        .0
     }
 
     pub(crate) fn compute_residual_and_gradient(
@@ -699,6 +740,7 @@ impl LineLineAngle {
         system.add_constraint(Edge::LineLineAngle(constraint))
     }
 
+    #[inline(always)]
     fn compute_residual_and_gradient_(variables: &[f64; 8], param_angle: f64) -> (f64, [f64; 8]) {
         let line1_point1 = kurbo::Point {
             x: variables[0],
@@ -751,6 +793,23 @@ impl LineLineAngle {
         ];
 
         (residual, gradient)
+    }
+
+    pub(crate) fn compute_residual(&self, variables: &[f64]) -> f64 {
+        Self::compute_residual_and_gradient_(
+            &[
+                variables[self.line1_point1_idx as usize],
+                variables[self.line1_point1_idx as usize + 1],
+                variables[self.line1_point2_idx as usize],
+                variables[self.line1_point2_idx as usize + 1],
+                variables[self.line2_point1_idx as usize],
+                variables[self.line2_point1_idx as usize + 1],
+                variables[self.line2_point2_idx as usize],
+                variables[self.line2_point2_idx as usize + 1],
+            ],
+            self.angle,
+        )
+        .0
     }
 
     pub(crate) fn compute_residual_and_gradient(
@@ -856,6 +915,7 @@ impl LineLineParallelism {
         }))
     }
 
+    #[inline(always)]
     fn compute_residual_and_gradient_(variables: &[f64; 8]) -> (f64, [f64; 8]) {
         let line1_point1 = kurbo::Point {
             x: variables[0],
@@ -891,6 +951,20 @@ impl LineLineParallelism {
         ];
 
         (residual, gradient)
+    }
+
+    pub(crate) fn compute_residual(&self, variables: &[f64]) -> f64 {
+        Self::compute_residual_and_gradient_(&[
+            variables[self.line1_point1_idx as usize],
+            variables[self.line1_point1_idx as usize + 1],
+            variables[self.line1_point2_idx as usize],
+            variables[self.line1_point2_idx as usize + 1],
+            variables[self.line2_point1_idx as usize],
+            variables[self.line2_point1_idx as usize + 1],
+            variables[self.line2_point2_idx as usize],
+            variables[self.line2_point2_idx as usize + 1],
+        ])
+        .0
     }
 
     pub(crate) fn compute_residual_and_gradient(
@@ -996,6 +1070,7 @@ impl LineCircleTangency {
         system.add_constraint(Edge::LineCircleTangency(constraint))
     }
 
+    #[inline(always)]
     fn compute_residual_and_gradient_(variables: &[f64; 7]) -> (f64, [f64; 7]) {
         let line_point1 = kurbo::Point {
             x: variables[0],
@@ -1050,6 +1125,19 @@ impl LineCircleTangency {
         ];
 
         (residual, gradient)
+    }
+
+    pub(crate) fn compute_residual(&self, variables: &[f64]) -> f64 {
+        Self::compute_residual_and_gradient_(&[
+            variables[self.line_point1_idx as usize],
+            variables[self.line_point1_idx as usize + 1],
+            variables[self.line_point2_idx as usize],
+            variables[self.line_point2_idx as usize + 1],
+            variables[self.circle_center_idx as usize],
+            variables[self.circle_center_idx as usize + 1],
+            variables[self.circle_radius_idx as usize],
+        ])
+        .0
     }
 
     pub(crate) fn compute_residual_and_gradient(

--- a/fiksi/src/utils.rs
+++ b/fiksi/src/utils.rs
@@ -7,6 +7,26 @@ use core::borrow::Borrow;
 
 use crate::{Edge, Subsystem};
 
+/// Compute residuals for all constraints.
+pub(crate) fn calculate_residuals(
+    subsystem: &Subsystem<'_>,
+    variables: &[f64],
+    residuals: &mut [f64],
+) {
+    residuals.fill(0.);
+
+    for (constraint_idx, constraint) in subsystem.constraints().enumerate() {
+        residuals[constraint_idx] = match constraint {
+            Edge::PointPointDistance(constraint) => constraint.compute_residual(variables),
+            Edge::PointPointPointAngle(constraint) => constraint.compute_residual(variables),
+            Edge::PointLineIncidence(constraint) => constraint.compute_residual(variables),
+            Edge::LineCircleTangency(constraint) => constraint.compute_residual(variables),
+            Edge::LineLineAngle(constraint) => constraint.compute_residual(variables),
+            Edge::LineLineParallelism(constraint) => constraint.compute_residual(variables),
+        };
+    }
+}
+
 /// Compute residuals and Jacobian for all constraints.
 ///
 /// The Jacobian is relative to the free variables.


### PR DESCRIPTION
On main, evaluating the residuals requires evaluating the Jacobian at the same time, even though for Levenberg-Marquardt we only need to recalculate the Jacobian when the step is accepted.