### PR TITLE
Rename system-level vertices and edges to `Encoded{Element,Constraint}`

### DIFF
--- a/fiksi/src/analyze/numerical/mod.rs
+++ b/fiksi/src/analyze/numerical/mod.rs
@@ -155,7 +155,7 @@ pub(crate) fn find_overconstraints(
             dependent.push(AnyConstraintHandle::from_ids_and_tag(
                 system.id,
                 id_in_system,
-                ConstraintTag::from(&system.constraint_edges[id_in_system as usize]),
+                ConstraintTag::from(&system.constraints[id_in_system as usize]),
             ));
         }
     }

--- a/fiksi/src/elements/mod.rs
+++ b/fiksi/src/elements/mod.rs
@@ -207,7 +207,7 @@ pub(crate) mod element {
 
 use element::ElementHandle;
 
-use crate::{System, EncodedElement};
+use crate::{EncodedElement, System};
 
 /// A point given by a 2D coordinate.
 #[derive(Debug)]
@@ -221,7 +221,9 @@ pub struct Point {
 impl Point {
     /// Construct a new `Point` at the given coordinate.
     pub fn create(system: &mut System, x: f64, y: f64) -> ElementHandle<Self> {
-        system.add_element([x, y], |variables_idx| EncodedElement::Point { idx: variables_idx })
+        system.add_element([x, y], |variables_idx| EncodedElement::Point {
+            idx: variables_idx,
+        })
     }
 }
 

--- a/fiksi/src/elements/mod.rs
+++ b/fiksi/src/elements/mod.rs
@@ -51,7 +51,7 @@ pub(crate) mod element {
             );
 
             <T as ElementInner>::from_vertex(
-                &system.element_vertices[self.drop_system_id().id as usize],
+                &system.elements[self.drop_system_id().id as usize],
                 &system.variables,
             )
             .into()
@@ -93,7 +93,7 @@ pub(crate) mod element {
                 "Tried to get an element that is not part of this `System`"
             );
 
-            let vertex = &system.element_vertices[self.id as usize];
+            let vertex = &system.elements[self.id as usize];
             match self.tag {
                 ElementTag::Point => {
                     ElementValue::Point(super::Point::from_vertex(vertex, &system.variables))
@@ -207,7 +207,7 @@ pub(crate) mod element {
 
 use element::ElementHandle;
 
-use crate::{System, Vertex};
+use crate::{System, EncodedElement};
 
 /// A point given by a 2D coordinate.
 #[derive(Debug)]
@@ -221,7 +221,7 @@ pub struct Point {
 impl Point {
     /// Construct a new `Point` at the given coordinate.
     pub fn create(system: &mut System, x: f64, y: f64) -> ElementHandle<Self> {
-        system.add_element([x, y], |variables_idx| Vertex::Point { idx: variables_idx })
+        system.add_element([x, y], |variables_idx| EncodedElement::Point { idx: variables_idx })
     }
 }
 
@@ -233,8 +233,8 @@ impl sealed::ElementInner for Point {
         ElementTag::Point
     }
 
-    fn from_vertex(vertex: &Vertex, variables: &[f64]) -> Self::Output {
-        let &Vertex::Point { idx } = vertex else {
+    fn from_vertex(vertex: &EncodedElement, variables: &[f64]) -> Self::Output {
+        let &EncodedElement::Point { idx } = vertex else {
             unreachable!()
         };
         kurbo::Point {
@@ -260,15 +260,15 @@ impl Line {
         point1: ElementHandle<Point>,
         point2: ElementHandle<Point>,
     ) -> ElementHandle<Self> {
-        let &Vertex::Point { idx: point1_idx } = &system.element_vertices[point1.id as usize]
+        let &EncodedElement::Point { idx: point1_idx } = &system.elements[point1.id as usize]
         else {
             unreachable!()
         };
-        let &Vertex::Point { idx: point2_idx } = &system.element_vertices[point2.id as usize]
+        let &EncodedElement::Point { idx: point2_idx } = &system.elements[point2.id as usize]
         else {
             unreachable!()
         };
-        system.add_element([], |_| Vertex::Line {
+        system.add_element([], |_| EncodedElement::Line {
             point1_idx,
             point2_idx,
         })
@@ -283,8 +283,8 @@ impl sealed::ElementInner for Line {
         ElementTag::Line
     }
 
-    fn from_vertex(vertex: &Vertex, variables: &[f64]) -> Self::Output {
-        let &Vertex::Line {
+    fn from_vertex(vertex: &EncodedElement, variables: &[f64]) -> Self::Output {
+        let &EncodedElement::Line {
             point1_idx,
             point2_idx,
         } = vertex
@@ -321,11 +321,11 @@ impl Circle {
         center: ElementHandle<Point>,
         radius: f64,
     ) -> ElementHandle<Self> {
-        let &Vertex::Point { idx: center_idx } = &system.element_vertices[center.id as usize]
+        let &EncodedElement::Point { idx: center_idx } = &system.elements[center.id as usize]
         else {
             unreachable!()
         };
-        system.add_element([radius], |radius_idx| Vertex::Circle {
+        system.add_element([radius], |radius_idx| EncodedElement::Circle {
             center_idx,
             radius_idx,
         })
@@ -340,8 +340,8 @@ impl sealed::ElementInner for Circle {
         ElementTag::Circle
     }
 
-    fn from_vertex(vertex: &Vertex, variables: &[f64]) -> kurbo::Circle {
-        let &Vertex::Circle {
+    fn from_vertex(vertex: &EncodedElement, variables: &[f64]) -> kurbo::Circle {
+        let &EncodedElement::Circle {
             center_idx,
             radius_idx,
         } = vertex
@@ -366,18 +366,18 @@ pub(crate) enum ElementTag {
     Circle,
 }
 
-impl<'a> From<&'a Vertex> for ElementTag {
-    fn from(vertex: &'a Vertex) -> Self {
+impl<'a> From<&'a EncodedElement> for ElementTag {
+    fn from(vertex: &'a EncodedElement) -> Self {
         match vertex {
-            Vertex::Point { .. } => Self::Point,
-            Vertex::Line { .. } => Self::Line,
-            Vertex::Circle { .. } => Self::Circle,
+            EncodedElement::Point { .. } => Self::Point,
+            EncodedElement::Line { .. } => Self::Line,
+            EncodedElement::Circle { .. } => Self::Circle,
         }
     }
 }
 
 pub(crate) mod sealed {
-    use crate::Vertex;
+    use crate::EncodedElement;
 
     pub(crate) trait ElementInner {
         /// The data type when retrieving an element's value.
@@ -387,7 +387,7 @@ pub(crate) mod sealed {
         type HandleData: Copy + core::fmt::Debug + Default;
 
         fn tag() -> super::ElementTag;
-        fn from_vertex(vertex: &Vertex, variables: &[f64]) -> Self::Output;
+        fn from_vertex(vertex: &EncodedElement, variables: &[f64]) -> Self::Output;
     }
 }
 

--- a/fiksi/src/lib.rs
+++ b/fiksi/src/lib.rs
@@ -112,7 +112,7 @@ pub(crate) enum EncodedElement {
 /// These are the constraints between geometric elements.
 ///
 /// These constraints have been flattened, in that they directly point to the variables in
-/// [`System::variables`] referenced by their original element arguments. 
+/// [`System::variables`] referenced by their original element arguments.
 pub(crate) enum EncodedConstraint {
     PointPointDistance(PointPointDistance),
     PointPointPointAngle(PointPointPointAngle),
@@ -266,16 +266,13 @@ impl System {
     /// You can use [`AnyElementHandle::get_value`] to get an element-tagged value or
     /// [`AnyElementHandle::as_tagged_element`] to get a typed handle.
     pub fn get_element_handles(&self) -> impl Iterator<Item = AnyElementHandle> {
-        self.elements
-            .iter()
-            .enumerate()
-            .map(|(id, vertex)| {
-                AnyElementHandle::from_ids_and_tag(
-                    self.id,
-                    id.try_into().expect("less than 2^32 elements"),
-                    vertex.into(),
-                )
-            })
+        self.elements.iter().enumerate().map(|(id, vertex)| {
+            AnyElementHandle::from_ids_and_tag(
+                self.id,
+                id.try_into().expect("less than 2^32 elements"),
+                vertex.into(),
+            )
+        })
     }
 
     /// Iterate over the handles of all constraints in the system.
@@ -342,7 +339,10 @@ impl System {
     /// Add a constraint.
     ///
     /// Give the constraint sets the constraint belongs to in `sets`.
-    pub(crate) fn add_constraint<T: Constraint>(&mut self, edge: EncodedConstraint) -> ConstraintHandle<T> {
+    pub(crate) fn add_constraint<T: Constraint>(
+        &mut self,
+        edge: EncodedConstraint,
+    ) -> ConstraintHandle<T> {
         let id = self
             .constraints
             .len()

--- a/fiksi/src/subsystem.rs
+++ b/fiksi/src/subsystem.rs
@@ -3,10 +3,10 @@
 
 use alloc::{collections::btree_map::BTreeMap, vec::Vec};
 
-use crate::{ConstraintId, Edge};
+use crate::{ConstraintId, EncodedConstraint};
 
 pub(crate) struct Subsystem<'s> {
-    edges: &'s [Edge],
+    edges: &'s [EncodedConstraint],
 
     /// The indices of free variables.
     free_variables: Vec<u32>,
@@ -19,7 +19,7 @@ pub(crate) struct Subsystem<'s> {
 
 impl<'s> Subsystem<'s> {
     pub(crate) fn new(
-        edges: &'s [Edge],
+        edges: &'s [EncodedConstraint],
         mut free_variables: Vec<u32>,
         constraints: Vec<ConstraintId>,
     ) -> Self {
@@ -44,7 +44,7 @@ impl<'s> Subsystem<'s> {
 
 impl Subsystem<'_> {
     #[inline(always)]
-    pub(crate) fn constraints(&self) -> impl ExactSizeIterator<Item = &Edge> {
+    pub(crate) fn constraints(&self) -> impl ExactSizeIterator<Item = &EncodedConstraint> {
         self.constraints
             .iter()
             .map(|constraint| &self.edges[constraint.id as usize])

--- a/fiksi/src/utils.rs
+++ b/fiksi/src/utils.rs
@@ -5,17 +5,21 @@
 
 use core::borrow::Borrow;
 
-use crate::{Edge, Subsystem};
+use crate::{EncodedConstraint, Subsystem};
 
 #[inline(always)]
-pub(crate) fn calculate_residual(constraint: &Edge, variables: &[f64]) -> f64 {
+pub(crate) fn calculate_residual(constraint: &EncodedConstraint, variables: &[f64]) -> f64 {
     match constraint {
-        Edge::PointPointDistance(constraint) => constraint.compute_residual(variables),
-        Edge::PointPointPointAngle(constraint) => constraint.compute_residual(variables),
-        Edge::PointLineIncidence(constraint) => constraint.compute_residual(variables),
-        Edge::LineCircleTangency(constraint) => constraint.compute_residual(variables),
-        Edge::LineLineAngle(constraint) => constraint.compute_residual(variables),
-        Edge::LineLineParallelism(constraint) => constraint.compute_residual(variables),
+        EncodedConstraint::PointPointDistance(constraint) => constraint.compute_residual(variables),
+        EncodedConstraint::PointPointPointAngle(constraint) => {
+            constraint.compute_residual(variables)
+        }
+        EncodedConstraint::PointLineIncidence(constraint) => constraint.compute_residual(variables),
+        EncodedConstraint::LineCircleTangency(constraint) => constraint.compute_residual(variables),
+        EncodedConstraint::LineLineAngle(constraint) => constraint.compute_residual(variables),
+        EncodedConstraint::LineLineParallelism(constraint) => {
+            constraint.compute_residual(variables)
+        }
     }
 }
 
@@ -48,7 +52,7 @@ pub(crate) fn calculate_residuals_and_jacobian(
 
     for (constraint_idx, constraint) in subsystem.constraints().enumerate() {
         match constraint {
-            Edge::PointPointDistance(constraint) => {
+            EncodedConstraint::PointPointDistance(constraint) => {
                 constraint.compute_residual_and_gradient(
                     subsystem,
                     variables,
@@ -57,7 +61,7 @@ pub(crate) fn calculate_residuals_and_jacobian(
                         ..(constraint_idx + 1) * num_free_variables],
                 );
             }
-            Edge::PointPointPointAngle(constraint) => {
+            EncodedConstraint::PointPointPointAngle(constraint) => {
                 constraint.compute_residual_and_gradient(
                     subsystem,
                     variables,
@@ -66,7 +70,7 @@ pub(crate) fn calculate_residuals_and_jacobian(
                         ..(constraint_idx + 1) * num_free_variables],
                 );
             }
-            Edge::PointLineIncidence(constraint) => {
+            EncodedConstraint::PointLineIncidence(constraint) => {
                 constraint.compute_residual_and_gradient(
                     subsystem,
                     variables,
@@ -75,7 +79,7 @@ pub(crate) fn calculate_residuals_and_jacobian(
                         ..(constraint_idx + 1) * num_free_variables],
                 );
             }
-            Edge::LineCircleTangency(constraint) => {
+            EncodedConstraint::LineCircleTangency(constraint) => {
                 constraint.compute_residual_and_gradient(
                     subsystem,
                     variables,
@@ -84,7 +88,7 @@ pub(crate) fn calculate_residuals_and_jacobian(
                         ..(constraint_idx + 1) * num_free_variables],
                 );
             }
-            Edge::LineLineAngle(constraint) => {
+            EncodedConstraint::LineLineAngle(constraint) => {
                 constraint.compute_residual_and_gradient(
                     subsystem,
                     variables,
@@ -93,7 +97,7 @@ pub(crate) fn calculate_residuals_and_jacobian(
                         ..(constraint_idx + 1) * num_free_variables],
                 );
             }
-            Edge::LineLineParallelism(constraint) => {
+            EncodedConstraint::LineLineParallelism(constraint) => {
                 constraint.compute_residual_and_gradient(
                     subsystem,
                     variables,


### PR DESCRIPTION
At the `System` level we are not tracking the graph directly, so the names are somewhat confusing.

This is part of some wider changes to primitive vs non-primitive elements.