### PR TITLE
Refactor constraints to provide one or more expressions

### DIFF
--- a/fiksi/src/constraints/expressions.rs
+++ b/fiksi/src/constraints/expressions.rs
@@ -1,0 +1,981 @@
+// Copyright 2025 the Fiksi Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#[cfg(not(feature = "std"))]
+use crate::floatfuncs::FloatFuncs;
+
+use crate::Subsystem;
+
+trait FloatExt {
+    /// Returns the square of `self`.
+    ///
+    /// Using `std`, you'd be able to do this using `self.powi(2)`, and have this be compiled to a
+    /// `self * self`. However, when compiling using `libm`, there is no `powi` and libm's
+    /// `self.powf(2.)` doesn't compile away.
+    fn square(self) -> Self;
+}
+
+impl FloatExt for f64 {
+    #[inline(always)]
+    fn square(self) -> Self {
+        self * self
+    }
+}
+
+pub(crate) enum Expression {
+    PointPointDistance(PointPointDistance),
+    PointPointPointAngle(PointPointPointAngle),
+    PointLineIncidence(PointLineIncidence),
+    LineLineAngle(LineLineAngle),
+    LineLineParallelism(LineLineParallelism),
+    LineCircleTangency(LineCircleTangency),
+}
+
+/// Constrain two points to have a given straight-line distance between each other.
+pub(crate) struct PointPointDistance {
+    pub(crate) point1_idx: u32,
+    pub(crate) point2_idx: u32,
+
+    /// Euclidean distance.
+    pub(crate) distance: f64,
+}
+
+impl From<PointPointDistance> for Expression {
+    fn from(expression: PointPointDistance) -> Self {
+        Self::PointPointDistance(expression)
+    }
+}
+
+impl PointPointDistance {
+    /// If only, say, the residual or some subset of the gradient entries are actually used, and
+    /// that is clear from the code at the call site, the compiler should be able to correctly
+    /// remove the dead calculations as this is marked as `#[inline(always)]`. That allows us not to
+    /// to duplicate code unnecessarily for the calculations. Plus, calculating the residuals and
+    /// the Jacobian at the same time is a common case, and for some constraints it's more efficient
+    /// when they're calculated together.
+    #[inline(always)]
+    fn compute_residual_and_gradient_(
+        variables: &[f64; 4],
+        param_distance: f64,
+    ) -> (f64, [f64; 4]) {
+        let point1 = kurbo::Point {
+            x: variables[0],
+            y: variables[1],
+        };
+        let point2 = kurbo::Point {
+            x: variables[2],
+            y: variables[3],
+        };
+
+        let distance = ((point1.x - point2.x).square() + (point1.y - point2.y).square()).sqrt();
+        let residual = distance - param_distance;
+
+        let distance_recip = 1. / distance;
+        let gradient = [
+            (point1.x - point2.x) * distance_recip,
+            (point1.y - point2.y) * distance_recip,
+            -(point1.x - point2.x) * distance_recip,
+            -(point1.y - point2.y) * distance_recip,
+        ];
+
+        (residual, gradient)
+    }
+
+    pub(crate) fn compute_residual(&self, variables: &[f64]) -> f64 {
+        // The compiler should be able to optimize this such that only the residual is calculated.
+        // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
+        Self::compute_residual_and_gradient_(
+            &[
+                variables[self.point1_idx as usize],
+                variables[self.point1_idx as usize + 1],
+                variables[self.point2_idx as usize],
+                variables[self.point2_idx as usize + 1],
+            ],
+            self.distance,
+        )
+        .0
+    }
+
+    pub(crate) fn compute_residual_and_gradient(
+        &self,
+        subsystem: &Subsystem<'_>,
+        variables: &[f64],
+        residual: &mut f64,
+        gradient: &mut [f64],
+    ) {
+        let (r, g) = Self::compute_residual_and_gradient_(
+            &[
+                variables[self.point1_idx as usize],
+                variables[self.point1_idx as usize + 1],
+                variables[self.point2_idx as usize],
+                variables[self.point2_idx as usize + 1],
+            ],
+            self.distance,
+        );
+
+        *residual += r;
+
+        if let Some(idx) = subsystem.free_variable_index(self.point1_idx) {
+            gradient[idx as usize] += g[0];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.point1_idx + 1) {
+            gradient[idx as usize] += g[1];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.point2_idx) {
+            gradient[idx as usize] += g[2];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.point2_idx + 1) {
+            gradient[idx as usize] += g[3];
+        }
+    }
+}
+
+/// Constrain three points to describe a given angle.
+pub(crate) struct PointPointPointAngle {
+    pub(crate) point1_idx: u32,
+    pub(crate) point2_idx: u32,
+    pub(crate) point3_idx: u32,
+
+    /// Angle in radians.
+    pub(crate) angle: f64,
+}
+
+impl From<PointPointPointAngle> for Expression {
+    fn from(expression: PointPointPointAngle) -> Self {
+        Self::PointPointPointAngle(expression)
+    }
+}
+
+impl PointPointPointAngle {
+    // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
+    #[inline(always)]
+    fn compute_residual_and_gradient_(variables: &[f64; 6], param_angle: f64) -> (f64, [f64; 6]) {
+        let point1 = kurbo::Point {
+            x: variables[0],
+            y: variables[1],
+        };
+        let point2 = kurbo::Point {
+            x: variables[2],
+            y: variables[3],
+        };
+        let point3 = kurbo::Point {
+            x: variables[4],
+            y: variables[5],
+        };
+
+        let u = point1 - point2;
+        let v = point3 - point2;
+
+        let angle = v.atan2() - u.atan2();
+        let angle = if angle > core::f64::consts::PI {
+            angle - 2.0 * core::f64::consts::PI
+        } else if angle < -core::f64::consts::PI {
+            angle + 2.0 * core::f64::consts::PI
+        } else {
+            angle
+        };
+
+        let residual = angle - param_angle;
+
+        let u_squared_recip = u.length_squared().recip();
+        let v_squared_recip = v.length_squared().recip();
+
+        let dangle_dpoint1x = u.y * u_squared_recip;
+        let dangle_dpoint1y = -u.x * u_squared_recip;
+        let dangle_dpoint3x = -v.y * v_squared_recip;
+        let dangle_dpoint3y = v.x * v_squared_recip;
+
+        let dangle_dpoint2x = -dangle_dpoint1x - dangle_dpoint3x;
+        let dangle_dpoint2y = -dangle_dpoint1y - dangle_dpoint3y;
+
+        let gradient = [
+            dangle_dpoint1x,
+            dangle_dpoint1y,
+            dangle_dpoint2x,
+            dangle_dpoint2y,
+            dangle_dpoint3x,
+            dangle_dpoint3y,
+        ];
+
+        (residual, gradient)
+    }
+
+    pub(crate) fn compute_residual(&self, variables: &[f64]) -> f64 {
+        // The compiler should be able to optimize this such that only the residual is calculated.
+        // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
+        Self::compute_residual_and_gradient_(
+            &[
+                variables[self.point1_idx as usize],
+                variables[self.point1_idx as usize + 1],
+                variables[self.point2_idx as usize],
+                variables[self.point2_idx as usize + 1],
+                variables[self.point3_idx as usize],
+                variables[self.point3_idx as usize + 1],
+            ],
+            self.angle,
+        )
+        .0
+    }
+
+    pub(crate) fn compute_residual_and_gradient(
+        &self,
+        subsystem: &Subsystem<'_>,
+        variables: &[f64],
+        residual: &mut f64,
+        gradient: &mut [f64],
+    ) {
+        let (r, g) = Self::compute_residual_and_gradient_(
+            &[
+                variables[self.point1_idx as usize],
+                variables[self.point1_idx as usize + 1],
+                variables[self.point2_idx as usize],
+                variables[self.point2_idx as usize + 1],
+                variables[self.point3_idx as usize],
+                variables[self.point3_idx as usize + 1],
+            ],
+            self.angle,
+        );
+
+        *residual += r;
+
+        if let Some(idx) = subsystem.free_variable_index(self.point1_idx) {
+            gradient[idx as usize] += g[0];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.point1_idx + 1) {
+            gradient[idx as usize] += g[1];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.point2_idx) {
+            gradient[idx as usize] += g[2];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.point2_idx + 1) {
+            gradient[idx as usize] += g[3];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.point3_idx) {
+            gradient[idx as usize] += g[4];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.point3_idx + 1) {
+            gradient[idx as usize] += g[5];
+        }
+    }
+}
+
+/// Constrain a point and a line such that the point lies on the (infinite) line.
+///
+/// Note this does not constrain the point to lie on the line *segment* defined by `line`. This is
+/// equivalent to constraining the three points (the two points of the line and the point proper)
+/// to be collinear.
+pub(crate) struct PointLineIncidence {
+    pub(crate) point_idx: u32,
+    pub(crate) line_point1_idx: u32,
+    pub(crate) line_point2_idx: u32,
+}
+
+impl From<PointLineIncidence> for Expression {
+    fn from(expression: PointLineIncidence) -> Self {
+        Self::PointLineIncidence(expression)
+    }
+}
+
+impl PointLineIncidence {
+    // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
+    #[inline(always)]
+    fn compute_residual_and_gradient_(variables: &[f64; 6]) -> (f64, [f64; 6]) {
+        let point1 = kurbo::Point {
+            x: variables[0],
+            y: variables[1],
+        };
+        let point2 = kurbo::Point {
+            x: variables[2],
+            y: variables[3],
+        };
+        let point3 = kurbo::Point {
+            x: variables[4],
+            y: variables[5],
+        };
+
+        // For collinear points, the triangle defined by those points has area 0.
+        let residual = point1.x * (point2.y - point3.y)
+            + point2.x * (point3.y - point1.y)
+            + point3.x * (point1.y - point2.y);
+
+        let gradient = [
+            point2.y - point3.y,
+            -point2.x + point3.x,
+            point3.y - point1.y,
+            point1.x - point3.x,
+            point1.y - point2.y,
+            -point1.x + point2.x,
+        ];
+
+        (residual, gradient)
+    }
+
+    pub(crate) fn compute_residual(&self, variables: &[f64]) -> f64 {
+        // The compiler should be able to optimize this such that only the residual is calculated.
+        // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
+        Self::compute_residual_and_gradient_(&[
+            variables[self.point_idx as usize],
+            variables[self.point_idx as usize + 1],
+            variables[self.line_point1_idx as usize],
+            variables[self.line_point1_idx as usize + 1],
+            variables[self.line_point2_idx as usize],
+            variables[self.line_point2_idx as usize + 1],
+        ])
+        .0
+    }
+
+    pub(crate) fn compute_residual_and_gradient(
+        &self,
+        subsystem: &Subsystem<'_>,
+        variables: &[f64],
+        residual: &mut f64,
+        gradient: &mut [f64],
+    ) {
+        let (r, g) = Self::compute_residual_and_gradient_(&[
+            variables[self.point_idx as usize],
+            variables[self.point_idx as usize + 1],
+            variables[self.line_point1_idx as usize],
+            variables[self.line_point1_idx as usize + 1],
+            variables[self.line_point2_idx as usize],
+            variables[self.line_point2_idx as usize + 1],
+        ]);
+
+        *residual += r;
+
+        if let Some(idx) = subsystem.free_variable_index(self.point_idx) {
+            gradient[idx as usize] += g[0];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.point_idx + 1) {
+            gradient[idx as usize] += g[1];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.line_point1_idx) {
+            gradient[idx as usize] += g[2];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.line_point1_idx + 1) {
+            gradient[idx as usize] += g[3];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.line_point2_idx) {
+            gradient[idx as usize] += g[4];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.line_point2_idx + 1) {
+            gradient[idx as usize] += g[5];
+        }
+    }
+}
+
+/// Constrain two lines to describe a given angle.
+pub(crate) struct LineLineAngle {
+    pub(crate) line1_point1_idx: u32,
+    pub(crate) line1_point2_idx: u32,
+    pub(crate) line2_point1_idx: u32,
+    pub(crate) line2_point2_idx: u32,
+
+    /// Angle in radians.
+    pub(crate) angle: f64,
+}
+
+impl From<LineLineAngle> for Expression {
+    fn from(expression: LineLineAngle) -> Self {
+        Self::LineLineAngle(expression)
+    }
+}
+
+impl LineLineAngle {
+    // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
+    #[inline(always)]
+    fn compute_residual_and_gradient_(variables: &[f64; 8], param_angle: f64) -> (f64, [f64; 8]) {
+        let line1_point1 = kurbo::Point {
+            x: variables[0],
+            y: variables[1],
+        };
+        let line1_point2 = kurbo::Point {
+            x: variables[2],
+            y: variables[3],
+        };
+        let line2_point1 = kurbo::Point {
+            x: variables[4],
+            y: variables[5],
+        };
+        let line2_point2 = kurbo::Point {
+            x: variables[6],
+            y: variables[7],
+        };
+
+        let u = line1_point2 - line1_point1;
+        let v = line2_point2 - line2_point1;
+
+        let angle = v.atan2() - u.atan2();
+        let angle = if angle > core::f64::consts::PI {
+            angle - 2.0 * core::f64::consts::PI
+        } else if angle < -core::f64::consts::PI {
+            angle + 2.0 * core::f64::consts::PI
+        } else {
+            angle
+        };
+
+        let residual = angle - param_angle;
+
+        let u_squared_recip = u.length_squared().recip();
+        let v_squared_recip = v.length_squared().recip();
+
+        let dangle_dline1_point1x = -u.y * u_squared_recip;
+        let dangle_dline1_point1y = u.x * u_squared_recip;
+        let dangle_dline2_point1x = v.y * v_squared_recip;
+        let dangle_dline2_point1y = -v.x * v_squared_recip;
+
+        let gradient = [
+            dangle_dline1_point1x,
+            dangle_dline1_point1y,
+            -dangle_dline1_point1x,
+            -dangle_dline1_point1y,
+            dangle_dline2_point1x,
+            dangle_dline2_point1y,
+            -dangle_dline2_point1x,
+            -dangle_dline2_point1y,
+        ];
+
+        (residual, gradient)
+    }
+
+    pub(crate) fn compute_residual(&self, variables: &[f64]) -> f64 {
+        // The compiler should be able to optimize this such that only the residual is calculated.
+        // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
+        Self::compute_residual_and_gradient_(
+            &[
+                variables[self.line1_point1_idx as usize],
+                variables[self.line1_point1_idx as usize + 1],
+                variables[self.line1_point2_idx as usize],
+                variables[self.line1_point2_idx as usize + 1],
+                variables[self.line2_point1_idx as usize],
+                variables[self.line2_point1_idx as usize + 1],
+                variables[self.line2_point2_idx as usize],
+                variables[self.line2_point2_idx as usize + 1],
+            ],
+            self.angle,
+        )
+        .0
+    }
+
+    pub(crate) fn compute_residual_and_gradient(
+        &self,
+        subsystem: &Subsystem<'_>,
+        variables: &[f64],
+        residual: &mut f64,
+        gradient: &mut [f64],
+    ) {
+        let (r, g) = Self::compute_residual_and_gradient_(
+            &[
+                variables[self.line1_point1_idx as usize],
+                variables[self.line1_point1_idx as usize + 1],
+                variables[self.line1_point2_idx as usize],
+                variables[self.line1_point2_idx as usize + 1],
+                variables[self.line2_point1_idx as usize],
+                variables[self.line2_point1_idx as usize + 1],
+                variables[self.line2_point2_idx as usize],
+                variables[self.line2_point2_idx as usize + 1],
+            ],
+            self.angle,
+        );
+
+        *residual += r;
+
+        if let Some(idx) = subsystem.free_variable_index(self.line1_point1_idx) {
+            gradient[idx as usize] += g[0];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.line1_point1_idx + 1) {
+            gradient[idx as usize] += g[1];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.line1_point2_idx) {
+            gradient[idx as usize] += g[2];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.line1_point2_idx + 1) {
+            gradient[idx as usize] += g[3];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.line2_point1_idx) {
+            gradient[idx as usize] += g[4];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.line2_point1_idx + 1) {
+            gradient[idx as usize] += g[5];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.line2_point2_idx) {
+            gradient[idx as usize] += g[6];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.line2_point2_idx + 1) {
+            gradient[idx as usize] += g[7];
+        }
+    }
+}
+
+/// Constrain two lines to be parallel to each other.
+pub(crate) struct LineLineParallelism {
+    pub(crate) line1_point1_idx: u32,
+    pub(crate) line1_point2_idx: u32,
+    pub(crate) line2_point1_idx: u32,
+    pub(crate) line2_point2_idx: u32,
+}
+
+impl From<LineLineParallelism> for Expression {
+    fn from(expression: LineLineParallelism) -> Self {
+        Self::LineLineParallelism(expression)
+    }
+}
+
+impl LineLineParallelism {
+    // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
+    #[inline(always)]
+    fn compute_residual_and_gradient_(variables: &[f64; 8]) -> (f64, [f64; 8]) {
+        let line1_point1 = kurbo::Point {
+            x: variables[0],
+            y: variables[1],
+        };
+        let line1_point2 = kurbo::Point {
+            x: variables[2],
+            y: variables[3],
+        };
+        let line2_point1 = kurbo::Point {
+            x: variables[4],
+            y: variables[5],
+        };
+        let line2_point2 = kurbo::Point {
+            x: variables[6],
+            y: variables[7],
+        };
+
+        let u = line1_point2 - line1_point1;
+        let v = line2_point2 - line2_point1;
+
+        let residual = v.cross(u);
+
+        let gradient = [
+            v.y,  // l1p1x
+            -v.x, // l1p1y
+            -v.y, // l1p2x
+            v.x,  // l1p2y
+            -u.y, // l2p1x
+            u.x,  // l2p1y
+            u.y,  // l2p2x
+            -u.x, // l2p2y
+        ];
+
+        (residual, gradient)
+    }
+
+    pub(crate) fn compute_residual(&self, variables: &[f64]) -> f64 {
+        // The compiler should be able to optimize this such that only the residual is calculated.
+        // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
+        Self::compute_residual_and_gradient_(&[
+            variables[self.line1_point1_idx as usize],
+            variables[self.line1_point1_idx as usize + 1],
+            variables[self.line1_point2_idx as usize],
+            variables[self.line1_point2_idx as usize + 1],
+            variables[self.line2_point1_idx as usize],
+            variables[self.line2_point1_idx as usize + 1],
+            variables[self.line2_point2_idx as usize],
+            variables[self.line2_point2_idx as usize + 1],
+        ])
+        .0
+    }
+
+    pub(crate) fn compute_residual_and_gradient(
+        &self,
+        subsystem: &Subsystem<'_>,
+        variables: &[f64],
+        residual: &mut f64,
+        gradient: &mut [f64],
+    ) {
+        let (r, g) = Self::compute_residual_and_gradient_(&[
+            variables[self.line1_point1_idx as usize],
+            variables[self.line1_point1_idx as usize + 1],
+            variables[self.line1_point2_idx as usize],
+            variables[self.line1_point2_idx as usize + 1],
+            variables[self.line2_point1_idx as usize],
+            variables[self.line2_point1_idx as usize + 1],
+            variables[self.line2_point2_idx as usize],
+            variables[self.line2_point2_idx as usize + 1],
+        ]);
+
+        *residual += r;
+
+        if let Some(idx) = subsystem.free_variable_index(self.line1_point1_idx) {
+            gradient[idx as usize] += g[0];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.line1_point1_idx + 1) {
+            gradient[idx as usize] += g[1];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.line1_point2_idx) {
+            gradient[idx as usize] += g[2];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.line1_point2_idx + 1) {
+            gradient[idx as usize] += g[3];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.line2_point1_idx) {
+            gradient[idx as usize] += g[4];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.line2_point1_idx + 1) {
+            gradient[idx as usize] += g[5];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.line2_point2_idx) {
+            gradient[idx as usize] += g[6];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.line2_point2_idx + 1) {
+            gradient[idx as usize] += g[7];
+        }
+    }
+}
+
+/// Constrain a line and a circle such that the line is tangent on the circle.
+pub(crate) struct LineCircleTangency {
+    pub(crate) line_point1_idx: u32,
+    pub(crate) line_point2_idx: u32,
+    pub(crate) circle_center_idx: u32,
+    pub(crate) circle_radius_idx: u32,
+}
+
+impl From<LineCircleTangency> for Expression {
+    fn from(expression: LineCircleTangency) -> Self {
+        Self::LineCircleTangency(expression)
+    }
+}
+
+impl LineCircleTangency {
+    // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
+    #[inline(always)]
+    fn compute_residual_and_gradient_(variables: &[f64; 7]) -> (f64, [f64; 7]) {
+        let line_point1 = kurbo::Point {
+            x: variables[0],
+            y: variables[1],
+        };
+        let line_point2 = kurbo::Point {
+            x: variables[2],
+            y: variables[3],
+        };
+        let circle_center = kurbo::Point {
+            x: variables[4],
+            y: variables[5],
+        };
+        let circle_radius = variables[6];
+
+        let length2 = line_point1.distance_squared(line_point2);
+        let length = length2.sqrt();
+
+        // TODO: better handle degenerate lines of length 0.
+        if length == 0. {
+            return (0., [0.; 7]);
+        }
+
+        let length_recip = 1. / length;
+        let signed_area = line_point1.x * (line_point2.y - circle_center.y)
+            + line_point2.x * (circle_center.y - line_point1.y)
+            + circle_center.x * (line_point1.y - line_point2.y);
+
+        // We are interested in the _unsigned_ area here, as it does not matter on which side of
+        // the line the circle center lies. That does mean there is a cusp when the circle
+        // center is exactly on the line.
+        let residual = length_recip * signed_area.abs() - circle_radius;
+
+        let sign = signed_area.signum();
+        let length3_recip = 1. / (length2 * length);
+        let gradient = [
+            sign * length3_recip
+                * (length2 * (line_point2.y - circle_center.y)
+                    + signed_area * (line_point2.x - line_point1.x)),
+            sign * length3_recip
+                * (length2 * (-line_point2.x + circle_center.x)
+                    + signed_area * (line_point2.y - line_point1.y)),
+            sign * length3_recip
+                * (length2 * (circle_center.y - line_point1.y)
+                    - signed_area * (line_point2.x - line_point1.x)),
+            sign * length3_recip
+                * (length2 * (line_point1.x - circle_center.x)
+                    - signed_area * (line_point2.y - line_point1.y)),
+            sign * length_recip * (line_point1.y - line_point2.y),
+            sign * length_recip * (-line_point1.x + line_point2.x),
+            -1.,
+        ];
+
+        (residual, gradient)
+    }
+
+    pub(crate) fn compute_residual(&self, variables: &[f64]) -> f64 {
+        // The compiler should be able to optimize this such that only the residual is calculated.
+        // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
+        Self::compute_residual_and_gradient_(&[
+            variables[self.line_point1_idx as usize],
+            variables[self.line_point1_idx as usize + 1],
+            variables[self.line_point2_idx as usize],
+            variables[self.line_point2_idx as usize + 1],
+            variables[self.circle_center_idx as usize],
+            variables[self.circle_center_idx as usize + 1],
+            variables[self.circle_radius_idx as usize],
+        ])
+        .0
+    }
+
+    pub(crate) fn compute_residual_and_gradient(
+        &self,
+        subsystem: &Subsystem<'_>,
+        variables: &[f64],
+        residual: &mut f64,
+        gradient: &mut [f64],
+    ) {
+        let (r, g) = Self::compute_residual_and_gradient_(&[
+            variables[self.line_point1_idx as usize],
+            variables[self.line_point1_idx as usize + 1],
+            variables[self.line_point2_idx as usize],
+            variables[self.line_point2_idx as usize + 1],
+            variables[self.circle_center_idx as usize],
+            variables[self.circle_center_idx as usize + 1],
+            variables[self.circle_radius_idx as usize],
+        ]);
+
+        *residual += r;
+
+        if let Some(idx) = subsystem.free_variable_index(self.line_point1_idx) {
+            gradient[idx as usize] += g[0];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.line_point1_idx + 1) {
+            gradient[idx as usize] += g[1];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.line_point2_idx) {
+            gradient[idx as usize] += g[2];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.line_point2_idx + 1) {
+            gradient[idx as usize] += g[3];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.circle_center_idx) {
+            gradient[idx as usize] += g[4];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.circle_center_idx + 1) {
+            gradient[idx as usize] += g[5];
+        }
+        if let Some(idx) = subsystem.free_variable_index(self.circle_radius_idx) {
+            gradient[idx as usize] += g[6];
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::array;
+
+    use crate::Rng;
+
+    use super::*;
+
+    /// Generate an array of random floats between 0. and 1. inclusive.
+    fn next_f64s<const N: usize>(rng: &mut Rng) -> [f64; N] {
+        array::from_fn(|_| rng.next_f64())
+    }
+
+    /// Calculate component-wise `a + b`.
+    fn add<const N: usize>(mut a: [f64; N], b: [f64; N]) -> [f64; N] {
+        for n in 0..N {
+            a[n] += b[n];
+        }
+        a
+    }
+
+    /// Calculate the dot product of a and b, `sum_n(a[n] * b[n])`.
+    fn dot<const N: usize>(a: [f64; N], b: [f64; N]) -> f64 {
+        let mut dot = 0.;
+        for n in 0..N {
+            dot += a[n] * b[n];
+        }
+        dot
+    }
+
+    /// For a given residual r(variables) and small step `delta` we assume
+    /// `r(variables + delta) ~= r(variables) + dot(gradient, delta)`
+    /// where `gradient` is the vector of partial derivatives `r'(variables)`.
+    ///
+    /// This tests whether that approximation actually holds.
+    fn test_first_finite_difference<const N: usize>(
+        residual_and_gradient: impl Fn(&[f64; N]) -> (f64, [f64; N]),
+        variable_and_delta_map: impl Fn([f64; N], [f64; N]) -> ([f64; N], [f64; N]),
+    ) {
+        const RELATIVE_EPSILON: f64 = 1e-3;
+        let mut rng = Rng::from_seed(42);
+
+        for _ in 0..5 {
+            let (variables, delta) =
+                variable_and_delta_map(next_f64s(&mut rng), next_f64s(&mut rng));
+            let (r, gradient) = residual_and_gradient(&variables);
+            let (r_plus, _) = residual_and_gradient(&add(variables, delta));
+
+            let linearized_diff = dot(gradient, delta);
+            let first_finite_diff = r_plus - r;
+
+            assert!(
+                (linearized_diff - first_finite_diff).abs()
+                    / f64::max(linearized_diff.abs(), first_finite_diff.abs())
+                    < RELATIVE_EPSILON,
+                "Difference predicted based on linearized first derivatives and actual first finite difference do not match.\n\
+                Variables: {variables:?}\n\
+                Delta: {delta:?}\n\
+                Predicted: {linearized_diff:?}\n\
+                Actual: {first_finite_diff:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn point_point_distance_first_finite_difference() {
+        test_first_finite_difference(
+            |variables| PointPointDistance::compute_residual_and_gradient_(variables, 0.5e0),
+            |variables, delta| {
+                (
+                    variables.map(|d| (d - 0.5) * 1e0),
+                    delta.map(|d| (d - 0.5) * 1e-4),
+                )
+            },
+        );
+        test_first_finite_difference(
+            |variables| PointPointDistance::compute_residual_and_gradient_(variables, 0.5e-9),
+            |variables, delta| {
+                (
+                    variables.map(|d| (d - 0.5) * 1e-10),
+                    delta.map(|d| (d - 0.5) * 1e-14),
+                )
+            },
+        );
+        test_first_finite_difference(
+            |variables| PointPointDistance::compute_residual_and_gradient_(variables, 0.5e10),
+            |variables, delta| {
+                (
+                    variables.map(|d| (d - 0.5) * 1e10),
+                    delta.map(|d| (d - 0.5) * 1e6),
+                )
+            },
+        );
+    }
+
+    #[test]
+    fn point_point_point_angle_first_finite_difference() {
+        test_first_finite_difference(
+            |variables| {
+                PointPointPointAngle::compute_residual_and_gradient_(variables, 10_f64.to_radians())
+            },
+            |variables, delta| {
+                (
+                    variables.map(|d| (d - 0.5) * 1e0),
+                    delta.map(|d| (d - 0.5) * 1e-5),
+                )
+            },
+        );
+        test_first_finite_difference(
+            |variables| {
+                PointPointPointAngle::compute_residual_and_gradient_(
+                    variables,
+                    -40_f64.to_radians(),
+                )
+            },
+            |variables, delta| {
+                (
+                    variables.map(|d| (d - 0.5) * 1e-10),
+                    delta.map(|d| (d - 0.5) * 1e-15),
+                )
+            },
+        );
+        test_first_finite_difference(
+            |variables| PointPointDistance::compute_residual_and_gradient_(variables, 0.5e10),
+            |variables, delta| {
+                (
+                    variables.map(|d| (d - 0.5) * 1e10),
+                    delta.map(|d| (d - 0.5) * 1e6),
+                )
+            },
+        );
+    }
+
+    #[test]
+    fn point_line_incidence_first_finite_difference() {
+        test_first_finite_difference(
+            PointLineIncidence::compute_residual_and_gradient_,
+            |variables, delta| {
+                (
+                    variables.map(|d| (d - 0.5) * 1e0),
+                    delta.map(|d| (d - 0.5) * 1e-4),
+                )
+            },
+        );
+        test_first_finite_difference(
+            PointLineIncidence::compute_residual_and_gradient_,
+            |variables, delta| {
+                (
+                    variables.map(|d| (d - 0.5) * 1e-10),
+                    delta.map(|d| (d - 0.5) * 1e-14),
+                )
+            },
+        );
+    }
+
+    #[test]
+    fn line_line_angle_first_finite_difference() {
+        test_first_finite_difference(
+            |variables| {
+                LineLineAngle::compute_residual_and_gradient_(variables, 10_f64.to_radians())
+            },
+            |variables, delta| {
+                (
+                    variables.map(|d| (d - 0.5) * 1e0),
+                    delta.map(|d| (d - 0.5) * 1e-4),
+                )
+            },
+        );
+        test_first_finite_difference(
+            |variables| {
+                LineLineAngle::compute_residual_and_gradient_(variables, -40_f64.to_radians())
+            },
+            |variables, delta| {
+                (
+                    variables.map(|d| (d - 0.5) * 1e-10),
+                    delta.map(|d| (d - 0.5) * 1e-14),
+                )
+            },
+        );
+    }
+
+    #[test]
+    fn line_line_parallelism_first_finite_difference() {
+        test_first_finite_difference(
+            LineLineParallelism::compute_residual_and_gradient_,
+            |variables, delta| {
+                (
+                    variables.map(|d| (d - 0.5) * 1e0),
+                    delta.map(|d| (d - 0.5) * 1e-4),
+                )
+            },
+        );
+        test_first_finite_difference(
+            LineLineParallelism::compute_residual_and_gradient_,
+            |variables, delta| {
+                (
+                    variables.map(|d| (d - 0.5) * 1e-10),
+                    delta.map(|d| (d - 0.5) * 1e-14),
+                )
+            },
+        );
+    }
+
+    #[test]
+    fn line_circle_tangency_first_finite_difference() {
+        test_first_finite_difference(
+            LineCircleTangency::compute_residual_and_gradient_,
+            |variables, delta| {
+                (
+                    variables.map(|d| (d - 0.5) * 1e0),
+                    delta.map(|d| (d - 0.5) * 1e-4),
+                )
+            },
+        );
+        test_first_finite_difference(
+            LineCircleTangency::compute_residual_and_gradient_,
+            |variables, delta| {
+                (
+                    variables.map(|d| (d - 0.5) * 1e-10),
+                    delta.map(|d| (d - 0.5) * 1e-14),
+                )
+            },
+        );
+    }
+}

--- a/fiksi/src/solve/lbfgs.rs
+++ b/fiksi/src/solve/lbfgs.rs
@@ -13,9 +13,9 @@ use crate::{
 /// The limited-memory BFGS solver by Liu and Nocedal (1989), approximating the
 /// Broyden–Fletcher–Goldfarb–Shanno method.
 ///
-/// Solve for the free variables in `variables` minimizing the sum of squared residuals of the constraints in
-/// `constraint_set`. The variables given by the elements in `element_set` are seen as free, other
-/// variables are seen as fixed parameters.
+/// Solve for the free variables in `variables` minimizing the sum of squared residuals of the
+/// expressions in the subsystem. The variables given by the elements in `element_set` are seen as
+/// free, other variables are seen as fixed parameters.
 ///
 /// See:
 /// Liu, Dong C., and Jorge Nocedal. "On the limited memory BFGS method for large scale
@@ -36,11 +36,11 @@ pub(crate) fn lbfgs(variables: &mut [f64], subsystem: &Subsystem<'_>) {
     /// have converged.
     const RESIDUAL_THRESHOLD: f64 = 1e-6;
 
-    // The (non-squared) residuals of the constraints.
-    let mut residuals = vec![0.; subsystem.constraints().len()];
-    // All first-order partial derivatives of the constraints, as constraints x free variables.
+    // The (non-squared) residuals of the expressions.
+    let mut residuals = vec![0.; subsystem.expressions().len()];
+    // All first-order partial derivatives of the expressions, as expressions x free variables.
     // This is in row-major order.
-    let mut jacobian = vec![0.; subsystem.constraints().len() * subsystem.free_variables().len()];
+    let mut jacobian = vec![0.; subsystem.expressions().len() * subsystem.free_variables().len()];
 
     // Calculate initial residuals and gradients
     calculate_residuals_and_jacobian(subsystem, &*variables, &mut residuals, &mut jacobian);
@@ -199,10 +199,10 @@ fn compute_gradient(jacobian: &[f64], residuals: &[f64], gradient: &mut [f64]) {
     gradient.fill(0.0);
 
     let num_variables = gradient.len();
-    let num_constraints = residuals.len();
+    let num_expressions = residuals.len();
 
     for i in 0..num_variables {
-        for c in 0..num_constraints {
+        for c in 0..num_expressions {
             gradient[i] += jacobian[c * num_variables + i] * residuals[c];
         }
     }

--- a/fiksi/src/solve/lm.rs
+++ b/fiksi/src/solve/lm.rs
@@ -15,8 +15,8 @@ use crate::{
 
 /// The Levenberg-Marquardt solver.
 ///
-/// Solve for the free variables in `variables` minimizing the residuals of the constraints in
-/// `constraint_set`. The variables given by the elements in `element_set` are seen as free, other
+/// Solve for the free variables in `variables` minimizing the residuals of the expressions in the
+/// subsystem. The variables given by the elements in `element_set` are seen as free, other
 /// variables are seen as fixed parameters.
 pub(crate) fn levenberg_marquardt(variables: &mut [f64], subsystem: &Subsystem<'_>) {
     // TODO: this is allocation-happy.
@@ -25,15 +25,15 @@ pub(crate) fn levenberg_marquardt(variables: &mut [f64], subsystem: &Subsystem<'
     let mut variables_scratch = variables.to_vec();
     let variables_scratch = variables_scratch.as_mut_slice();
 
-    // The (non-squared) residuals of the constraints.
-    let mut residuals = nalgebra::DVector::zeros(subsystem.constraints().len());
-    let mut residuals_scratch = nalgebra::DVector::zeros(subsystem.constraints().len());
+    // The (non-squared) residuals of the expressions.
+    let mut residuals = nalgebra::DVector::zeros(subsystem.expressions().len());
+    let mut residuals_scratch = nalgebra::DVector::zeros(subsystem.expressions().len());
 
-    // All first-order partial derivatives of the constraints. This is a dense representation (each
-    // pair of constraint and variable has a partial derivative represented here, even for
-    // variables that do not contribute to the constraint). It's possible a sparse representation
+    // All first-order partial derivatives of the expressions. This is a dense representation (each
+    // pair of expression and variable has a partial derivative represented here, even for
+    // variables that do not contribute to the expression). It's possible a sparse representation
     // may be more efficient in certain cases.
-    let mut jacobian = vec![0.; subsystem.constraints().len() * subsystem.free_variables().len()];
+    let mut jacobian = vec![0.; subsystem.expressions().len() * subsystem.free_variables().len()];
 
     calculate_residuals_and_jacobian(
         subsystem,
@@ -53,10 +53,10 @@ pub(crate) fn levenberg_marquardt(variables: &mut [f64], subsystem: &Subsystem<'
         // Clone the Jacobian to a nalgebra matrix for now.
         // TODO: remove
         let mut jacobian_ = nalgebra::DMatrix::zeros(
-            subsystem.constraints().len(),
+            subsystem.expressions().len(),
             subsystem.free_variables().len(),
         );
-        for i in 0..subsystem.constraints().len() {
+        for i in 0..subsystem.expressions().len() {
             for j in 0..subsystem.free_variables().len() {
                 jacobian_[(i, j)] = jacobian[i * subsystem.free_variables().len() + j];
             }

--- a/fiksi/src/subsystem.rs
+++ b/fiksi/src/subsystem.rs
@@ -3,15 +3,15 @@
 
 use alloc::{collections::btree_map::BTreeMap, vec::Vec};
 
-use crate::{ConstraintId, EncodedConstraint};
+use crate::Expression;
 
 pub(crate) struct Subsystem<'s> {
-    /// All constraints in the [`crate::System`] this subsystem belongs to.
-    all_constraints: &'s [EncodedConstraint],
+    /// All expressions in the [`crate::System`] this subsystem belongs to.
+    all_expressions: &'s [Expression],
 
-    /// The constraints that are part of this subsystem. These are indices into
-    /// [`Self::all_constraints`].
-    constraints: Vec<ConstraintId>,
+    /// The expressions that are part of this subsystem. These are indices into
+    /// [`Self::all_expressions`].
+    expressions: Vec<u32>,
 
     /// The indices of free variables.
     free_variables: Vec<u32>,
@@ -22,9 +22,9 @@ pub(crate) struct Subsystem<'s> {
 
 impl<'s> Subsystem<'s> {
     pub(crate) fn new(
-        all_constraints: &'s [EncodedConstraint],
+        all_expressions: &'s [Expression],
         mut free_variables: Vec<u32>,
-        constraints: Vec<ConstraintId>,
+        expressions: Vec<u32>,
     ) -> Self {
         free_variables.sort_unstable();
 
@@ -37,25 +37,26 @@ impl<'s> Subsystem<'s> {
         }
 
         Self {
-            all_constraints,
+            all_expressions,
             free_variables,
             variable_to_free_variable,
-            constraints,
+            expressions,
         }
     }
 }
 
 impl Subsystem<'_> {
     #[inline(always)]
-    pub(crate) fn constraints(&self) -> impl ExactSizeIterator<Item = &EncodedConstraint> {
-        self.constraints
+    pub(crate) fn expressions(&self) -> impl ExactSizeIterator<Item = &Expression> {
+        self.expressions
             .iter()
-            .map(|constraint| &self.all_constraints[constraint.id as usize])
+            .copied()
+            .map(|expression| &self.all_expressions[expression as usize])
     }
 
     #[inline(always)]
-    pub(crate) fn constraint_ids(&self) -> impl ExactSizeIterator<Item = ConstraintId> {
-        self.constraints.iter().copied()
+    pub(crate) fn expression_ids(&self) -> impl ExactSizeIterator<Item = u32> {
+        self.expressions.iter().copied()
     }
 
     #[inline(always)]

--- a/fiksi/src/utils.rs
+++ b/fiksi/src/utils.rs
@@ -5,25 +5,21 @@
 
 use core::borrow::Borrow;
 
-use crate::{EncodedConstraint, Subsystem};
+use crate::{Expression, Subsystem};
 
 #[inline(always)]
-pub(crate) fn calculate_residual(constraint: &EncodedConstraint, variables: &[f64]) -> f64 {
-    match constraint {
-        EncodedConstraint::PointPointDistance(constraint) => constraint.compute_residual(variables),
-        EncodedConstraint::PointPointPointAngle(constraint) => {
-            constraint.compute_residual(variables)
-        }
-        EncodedConstraint::PointLineIncidence(constraint) => constraint.compute_residual(variables),
-        EncodedConstraint::LineCircleTangency(constraint) => constraint.compute_residual(variables),
-        EncodedConstraint::LineLineAngle(constraint) => constraint.compute_residual(variables),
-        EncodedConstraint::LineLineParallelism(constraint) => {
-            constraint.compute_residual(variables)
-        }
+pub(crate) fn calculate_residual(expression: &Expression, variables: &[f64]) -> f64 {
+    match expression {
+        Expression::PointPointDistance(expression) => expression.compute_residual(variables),
+        Expression::PointPointPointAngle(expression) => expression.compute_residual(variables),
+        Expression::PointLineIncidence(expression) => expression.compute_residual(variables),
+        Expression::LineCircleTangency(expression) => expression.compute_residual(variables),
+        Expression::LineLineAngle(expression) => expression.compute_residual(variables),
+        Expression::LineLineParallelism(expression) => expression.compute_residual(variables),
     }
 }
 
-/// Compute residuals for all constraints.
+/// Compute residuals for all expressions.
 pub(crate) fn calculate_residuals(
     subsystem: &Subsystem<'_>,
     variables: &[f64],
@@ -31,8 +27,8 @@ pub(crate) fn calculate_residuals(
 ) {
     residuals.fill(0.);
 
-    for (constraint_idx, constraint) in subsystem.constraints().enumerate() {
-        residuals[constraint_idx] = calculate_residual(constraint, variables);
+    for (expression_idx, expression) in subsystem.expressions().enumerate() {
+        residuals[expression_idx] = calculate_residual(expression, variables);
     }
 }
 
@@ -50,60 +46,60 @@ pub(crate) fn calculate_residuals_and_jacobian(
 
     let num_free_variables = subsystem.free_variables().len();
 
-    for (constraint_idx, constraint) in subsystem.constraints().enumerate() {
-        match constraint {
-            EncodedConstraint::PointPointDistance(constraint) => {
-                constraint.compute_residual_and_gradient(
+    for (expression_idx, expression) in subsystem.expressions().enumerate() {
+        match expression {
+            Expression::PointPointDistance(expression) => {
+                expression.compute_residual_and_gradient(
                     subsystem,
                     variables,
-                    &mut residuals[constraint_idx],
-                    &mut jacobian[constraint_idx * num_free_variables
-                        ..(constraint_idx + 1) * num_free_variables],
+                    &mut residuals[expression_idx],
+                    &mut jacobian[expression_idx * num_free_variables
+                        ..(expression_idx + 1) * num_free_variables],
                 );
             }
-            EncodedConstraint::PointPointPointAngle(constraint) => {
-                constraint.compute_residual_and_gradient(
+            Expression::PointPointPointAngle(expression) => {
+                expression.compute_residual_and_gradient(
                     subsystem,
                     variables,
-                    &mut residuals[constraint_idx],
-                    &mut jacobian[constraint_idx * num_free_variables
-                        ..(constraint_idx + 1) * num_free_variables],
+                    &mut residuals[expression_idx],
+                    &mut jacobian[expression_idx * num_free_variables
+                        ..(expression_idx + 1) * num_free_variables],
                 );
             }
-            EncodedConstraint::PointLineIncidence(constraint) => {
-                constraint.compute_residual_and_gradient(
+            Expression::PointLineIncidence(expression) => {
+                expression.compute_residual_and_gradient(
                     subsystem,
                     variables,
-                    &mut residuals[constraint_idx],
-                    &mut jacobian[constraint_idx * num_free_variables
-                        ..(constraint_idx + 1) * num_free_variables],
+                    &mut residuals[expression_idx],
+                    &mut jacobian[expression_idx * num_free_variables
+                        ..(expression_idx + 1) * num_free_variables],
                 );
             }
-            EncodedConstraint::LineCircleTangency(constraint) => {
-                constraint.compute_residual_and_gradient(
+            Expression::LineCircleTangency(expression) => {
+                expression.compute_residual_and_gradient(
                     subsystem,
                     variables,
-                    &mut residuals[constraint_idx],
-                    &mut jacobian[constraint_idx * num_free_variables
-                        ..(constraint_idx + 1) * num_free_variables],
+                    &mut residuals[expression_idx],
+                    &mut jacobian[expression_idx * num_free_variables
+                        ..(expression_idx + 1) * num_free_variables],
                 );
             }
-            EncodedConstraint::LineLineAngle(constraint) => {
-                constraint.compute_residual_and_gradient(
+            Expression::LineLineAngle(expression) => {
+                expression.compute_residual_and_gradient(
                     subsystem,
                     variables,
-                    &mut residuals[constraint_idx],
-                    &mut jacobian[constraint_idx * num_free_variables
-                        ..(constraint_idx + 1) * num_free_variables],
+                    &mut residuals[expression_idx],
+                    &mut jacobian[expression_idx * num_free_variables
+                        ..(expression_idx + 1) * num_free_variables],
                 );
             }
-            EncodedConstraint::LineLineParallelism(constraint) => {
-                constraint.compute_residual_and_gradient(
+            Expression::LineLineParallelism(expression) => {
+                expression.compute_residual_and_gradient(
                     subsystem,
                     variables,
-                    &mut residuals[constraint_idx],
-                    &mut jacobian[constraint_idx * num_free_variables
-                        ..(constraint_idx + 1) * num_free_variables],
+                    &mut residuals[expression_idx],
+                    &mut jacobian[expression_idx * num_free_variables
+                        ..(expression_idx + 1) * num_free_variables],
                 );
             }
         }


### PR DESCRIPTION
This decouples constraints from residual calculation by introducing expressions, allowing us to introduce constraints that provide more than one residual. This is useful for having constraints with a valency larger than one (like point-point coincidences, which have a valency of 2 in 2D).

Parts of the code working at the residual-level, like the optimizers, can now continue working on a flat list of expressions, rather than operating on a list of constraints with differing valency.