### PR TITLE
Add point-point coincidence constraint

### DIFF
--- a/fiksi/src/constraints/mod.rs
+++ b/fiksi/src/constraints/mod.rs
@@ -10,6 +10,9 @@ use crate::{
 pub(crate) mod expressions;
 
 pub(crate) mod constraint {
+    #[cfg(not(feature = "std"))]
+    use crate::floatfuncs::FloatFuncs;
+
     use core::marker::PhantomData;
 
     use crate::{System, utils};

--- a/fiksi/src/constraints/mod.rs
+++ b/fiksi/src/constraints/mod.rs
@@ -254,6 +254,9 @@ pub(crate) mod constraint {
 }
 
 /// Constrain two points to be exactly at the same place.
+///
+/// If you want to constrain points such that they are a given distance from each other, use
+/// [`PointPointDistance`].
 pub struct PointPointCoincidence {
     point1_idx: u32,
     point2_idx: u32,
@@ -306,6 +309,10 @@ impl PointPointCoincidence {
 }
 
 /// Constrain two points to have a given straight-line distance between each other.
+///
+/// If you want to constrain two points to be at the exact same location, i.e., having a distance
+/// of 0, use [`PointPointCoincidence`] instead. Using [`PointPointDistance`] is numerically
+/// singular at a distance of 0.
 pub struct PointPointDistance {}
 
 impl sealed::ConstraintInner for PointPointDistance {

--- a/fiksi/src/constraints/mod.rs
+++ b/fiksi/src/constraints/mod.rs
@@ -18,6 +18,9 @@ pub(crate) mod constraint {
 
     /// Dynamically tagged, typed handles to constraints.
     pub enum TaggedConstraintHandle {
+        /// A handle to a [`PointPointCoincidence`](super::PointPointCoincidence) constraint.
+        PointPointCoincidence(ConstraintHandle<super::PointPointCoincidence>),
+
         /// A handle to a [`PointPointDistance`](super::PointPointDistance) constraint.
         PointPointDistance(ConstraintHandle<super::PointPointDistance>),
 
@@ -60,6 +63,9 @@ pub(crate) mod constraint {
         }
 
         /// Calculate the residual of this constraint.
+        ///
+        /// If the constraint referenced by the handle contributes more than one residual, this
+        /// calculates the square root of the sum of its squared residuals.
         pub fn calculate_residual(self, system: &System) -> f64 {
             // TODO: return `Result` instead of panicking?
             assert_eq!(
@@ -67,10 +73,19 @@ pub(crate) mod constraint {
                 "Tried to evaluate a constraint that is not part of this `System`"
             );
 
-            // TODO: handle constraints with `valency > 1`
             let constraint = &system.constraints[self.id as usize];
-            let expression = &system.expressions[constraint.expressions_idx as usize];
-            utils::calculate_residual(expression, &system.variables)
+            if T::VALENCY > 1 {
+                utils::sum_squares((0..T::VALENCY).map(|offset| {
+                    utils::calculate_residual(
+                        &system.expressions[constraint.expressions_idx as usize + offset as usize],
+                        &system.variables,
+                    )
+                }))
+                .sqrt()
+            } else {
+                let expression = &system.expressions[constraint.expressions_idx as usize];
+                utils::calculate_residual(expression, &system.variables)
+            }
         }
 
         /// Get a type-erased handle to the constraint.
@@ -102,6 +117,9 @@ pub(crate) mod constraint {
         }
 
         /// Get the value of the constraint.
+        ///
+        /// If the constraint referenced by the handle contributes more than one residual, this
+        /// calculates the square root of the sum of its squared residuals.
         pub fn calculate_residual(&self, system: &System) -> f64 {
             // TODO: return `Result` instead of panicking?
             assert_eq!(
@@ -109,15 +127,31 @@ pub(crate) mod constraint {
                 "Tried to get a constraint that is not part of this `System`"
             );
 
-            // TODO: handle constraints with `valency > 1`
+            let valency = self.tag.valency();
             let constraint = &system.constraints[self.id as usize];
-            let expression = &system.expressions[constraint.expressions_idx as usize];
-            utils::calculate_residual(expression, &system.variables)
+            if valency > 1 {
+                utils::sum_squares((0..valency).map(|offset| {
+                    utils::calculate_residual(
+                        &system.expressions[constraint.expressions_idx as usize + offset as usize],
+                        &system.variables,
+                    )
+                }))
+                .sqrt()
+            } else {
+                let expression = &system.expressions[constraint.expressions_idx as usize];
+                utils::calculate_residual(expression, &system.variables)
+            }
         }
 
         /// Get a typed handle to the constraint.
         pub fn as_tagged_constraint(self) -> TaggedConstraintHandle {
             match self.tag {
+                ConstraintTag::PointPointCoincidence => {
+                    TaggedConstraintHandle::PointPointCoincidence(ConstraintHandle::from_ids(
+                        self.system_id,
+                        self.id,
+                    ))
+                }
                 ConstraintTag::PointPointDistance => TaggedConstraintHandle::PointPointDistance(
                     ConstraintHandle::from_ids(self.system_id, self.id),
                 ),
@@ -216,6 +250,58 @@ pub(crate) mod constraint {
     pub(crate) struct ConstraintId {
         /// The ID of the constraint within the system.
         pub(crate) id: u32,
+    }
+}
+
+/// Constrain two points to be exactly at the same place.
+pub struct PointPointCoincidence {
+    point1_idx: u32,
+    point2_idx: u32,
+}
+
+impl sealed::ConstraintInner for PointPointCoincidence {
+    fn tag() -> ConstraintTag {
+        ConstraintTag::PointPointCoincidence
+    }
+}
+
+impl PointPointCoincidence {
+    /// Construct a constraint between two points to be exactly at the same place.
+    pub fn create(
+        system: &mut System,
+        point1: ElementHandle<elements::Point>,
+        point2: ElementHandle<elements::Point>,
+    ) -> ConstraintHandle<Self> {
+        let &EncodedElement::Point { idx: point1_idx } = &system.elements[point1.id as usize]
+        else {
+            unreachable!()
+        };
+        let &EncodedElement::Point { idx: point2_idx } = &system.elements[point2.id as usize]
+        else {
+            unreachable!()
+        };
+
+        system.graph.add_constraint(
+            2,
+            IncidentElements::from_array([point1.drop_system_id(), point2.drop_system_id()]),
+        );
+        system.add_constraint(
+            ConstraintTag::PointPointCoincidence,
+            [
+                // Linear difference along the x-axis
+                expressions::VariableVariableEquality {
+                    variable1_idx: point1_idx,
+                    variable2_idx: point2_idx,
+                }
+                .into(),
+                // Linear difference along the y-axis
+                expressions::VariableVariableEquality {
+                    variable1_idx: point1_idx + 1,
+                    variable2_idx: point2_idx + 1,
+                }
+                .into(),
+            ],
+        )
     }
 }
 
@@ -534,6 +620,7 @@ impl LineCircleTangency {
 /// The actual type of the constraint.
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum ConstraintTag {
+    PointPointCoincidence,
     PointPointDistance,
     PointPointPointAngle,
     PointLineIncidence,
@@ -545,6 +632,7 @@ pub(crate) enum ConstraintTag {
 impl ConstraintTag {
     pub(crate) fn valency(self) -> u8 {
         match self {
+            Self::PointPointCoincidence => PointPointCoincidence::VALENCY,
             Self::PointPointDistance => PointPointDistance::VALENCY,
             Self::PointPointPointAngle => PointPointPointAngle::VALENCY,
             Self::PointLineIncidence => PointLineIncidence::VALENCY,
@@ -573,6 +661,10 @@ pub trait Constraint: sealed::ConstraintInner {
     ///
     /// This is the number of degrees of freedom taken away by the constraint.
     const VALENCY: u8;
+}
+
+impl Constraint for PointPointCoincidence {
+    const VALENCY: u8 = 2;
 }
 
 impl Constraint for PointPointDistance {

--- a/fiksi/src/tests/basic.rs
+++ b/fiksi/src/tests/basic.rs
@@ -7,6 +7,24 @@ use super::RESIDUAL_THRESHOLD;
 
 /// Tests whether an under-constrained triangle configuration gets solved.
 #[test]
+fn coincident_points() {
+    let mut s = System::new();
+
+    let p0 = elements::Point::create(&mut s, 0., 0.);
+    let p1 = elements::Point::create(&mut s, 1., 0.5);
+    let coincidence = constraints::PointPointCoincidence::create(&mut s, p0, p1);
+
+    s.solve(None, crate::SolvingOptions::default());
+
+    let sum_squared_residuals = sum_squares([coincidence.calculate_residual(&s)]);
+    assert!(
+        sum_squared_residuals < RESIDUAL_THRESHOLD,
+        "The system was not solved (sum of squared residuals: {sum_squared_residuals})"
+    );
+}
+
+/// Tests whether an under-constrained triangle configuration gets solved.
+#[test]
 fn underconstrained_triangle() {
     let mut s = System::new();
 

--- a/fiksi/src/tests/basic.rs
+++ b/fiksi/src/tests/basic.rs
@@ -5,7 +5,7 @@ use crate::{System, constraints, elements, utils::sum_squares};
 
 use super::RESIDUAL_THRESHOLD;
 
-/// Tests whether an under-constrained triangle configuration gets solved.
+/// Tests whether a point-point coincidence configuration gets solved.
 #[test]
 fn coincident_points() {
     let mut s = System::new();
@@ -20,6 +20,14 @@ fn coincident_points() {
     assert!(
         sum_squared_residuals < RESIDUAL_THRESHOLD,
         "The system was not solved (sum of squared residuals: {sum_squared_residuals})"
+    );
+
+    // Similarly to testing the residual, we can test whether the points are actually moved close
+    // together.
+    let distance = p0.get_value(&s).distance(p1.get_value(&s));
+    assert!(
+        distance < RESIDUAL_THRESHOLD.sqrt(),
+        "The points did not actually become coincident (remaining distance: {distance})"
     );
 }
 

--- a/fiksi/src/utils.rs
+++ b/fiksi/src/utils.rs
@@ -10,6 +10,7 @@ use crate::{Expression, Subsystem};
 #[inline(always)]
 pub(crate) fn calculate_residual(expression: &Expression, variables: &[f64]) -> f64 {
     match expression {
+        Expression::VariableVariableEquality(expression) => expression.compute_residual(variables),
         Expression::PointPointDistance(expression) => expression.compute_residual(variables),
         Expression::PointPointPointAngle(expression) => expression.compute_residual(variables),
         Expression::PointLineIncidence(expression) => expression.compute_residual(variables),
@@ -48,6 +49,15 @@ pub(crate) fn calculate_residuals_and_jacobian(
 
     for (expression_idx, expression) in subsystem.expressions().enumerate() {
         match expression {
+            Expression::VariableVariableEquality(expression) => {
+                expression.compute_residual_and_gradient(
+                    subsystem,
+                    variables,
+                    &mut residuals[expression_idx],
+                    &mut jacobian[expression_idx * num_free_variables
+                        ..(expression_idx + 1) * num_free_variables],
+                );
+            }
             Expression::PointPointDistance(expression) => {
                 expression.compute_residual_and_gradient(
                     subsystem,


### PR DESCRIPTION
Closes https://github.com/endoli/fiksi/issues/62.

On top of https://github.com/endoli/fiksi/pull/67, which introduces the required mechanism.

This constraint is quite different from the ones already in main, as it has a valency of 2, i.e., it takes away two degrees of freedom. (Say one of the two points constrained by a point-point coincidence is fixed, then the other point has no degrees of freedom left. To satisfy the constraint, it has to be at the exact same location.)

This is best modeled by introducing two residuals, one linear distance along the x-axis and one along the y-axis, as this is numerically more than a `PointPointDistance` constraint with `distance` parameter 0.