### PR TITLE
Add utility geometry construction methods

### DIFF
--- a/fiksi/src/lib.rs
+++ b/fiksi/src/lib.rs
@@ -72,6 +72,7 @@ mod rand;
 pub mod solve;
 mod subsystem;
 pub(crate) mod utils;
+mod vocabulary;
 
 #[cfg(test)]
 mod tests;

--- a/fiksi/src/vocabulary.rs
+++ b/fiksi/src/vocabulary.rs
@@ -1,0 +1,49 @@
+// Copyright 2025 the Fiksi Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Vocabulary for some common geometric constructions.
+
+use crate::{ElementHandle, System, constraints, elements};
+
+impl ElementHandle<elements::Line> {
+    pub fn create_incident_point(self, system: &mut System) -> ElementHandle<elements::Point> {
+        let current = self.get_value(system);
+        let p = elements::Point::create(system, current.p0.x, current.p0.y);
+        constraints::PointLineIncidence::create(system, p, self);
+        p
+    }
+}
+
+impl ElementHandle<elements::Circle> {
+    pub fn create_point_at_center(self, system: &mut System) -> ElementHandle<elements::Point> {
+        let current = self.get_value(system);
+        let p = elements::Point::create(system, current.center.x, current.center.y);
+        constraints::PointCircleCentrality::create(system, p, self);
+        p
+    }
+
+    pub fn create_incident_point(self, system: &mut System) -> ElementHandle<elements::Point> {
+        let current = self.get_value(system);
+        let p =
+            elements::Point::create(system, current.center.x + current.radius, current.center.y);
+        constraints::PointCircleIncidence::create(system, p, self);
+        p
+    }
+
+    pub fn create_tangent_line(self, system: &mut System) -> ElementHandle<elements::Line> {
+        let current = self.get_value(system);
+        let p0 = elements::Point::create(
+            system,
+            current.center.x + current.radius,
+            current.center.y - current.radius,
+        );
+        let p1 = elements::Point::create(
+            system,
+            current.center.x + current.radius,
+            current.center.y + current.radius,
+        );
+        let line = elements::Line::create(system, p0, p1);
+        constraints::LineCircleTangency::create(system, line, self);
+        line
+    }
+}


### PR DESCRIPTION
See the last commit: https://github.com/endoli/fiksi/commit/8e127d65c7085ab42af6350305ef01b89ffc9d58.

This starts thinking about utility construction methods, to expressively build geometry on top of other geometry. This is directly motivated to allow potentially dropping the current references system (where, e.g., a circle is constructed from a reference to a point and [a reference to a length](https://github.com/endoli/fiksi/pull/51), and constraints can simultaneously be placed on the referenced point and the circle built on top of it).

These methods introduce a way of constructing the same kind of geometry through the normal constraint system. This can be more expressive, as it allows creating geometry that cannot be represented directly with references (e.g., something like `elements::Rectangle::point_at_top_right`, where the rectangle is not represented by a point in that location). There is some cost, as references are "free": they represent the same variables, and thus their relationships are trivially true. On the other hand, references make degree-of-freedom analysis harder, thereby complicating system analysis and decomposition.

For example, instead of the following.

```rust
let mut s = System::new();

let center = elements::Point::create(&mut s, 0., 0.);
let p1 = elements::Point::create(&mut s, 5., 0.);
let p2 = elements::Point::create(&mut s, 10., 1.);
let circle = elements::Circle::create(&mut s, center, 2.);

constraints::PointCircleIncidence::create(&mut s, p1, circle);
constraints::PointCircleIncidence::create(&mut s, p2, circle);
constraints::PointPointPointAngle::create(&mut s, p1, center, p2, 20_f64.to_radians());
constraints::PointPointDistance::create(&mut s, p1, p2, 15.);
```

You'd write the following.

```rust
let mut s = System::new();

let circle = elements::Circle::create(&mut s, (0., 0.), 2.);
let center = circle.create_point_at_center(&mut s);
let p1 = circle.create_incident_point(&mut s);
let p2 = circle.create_incident_point(&mut s);

constraints::PointPointPointAngle::create(&mut s, p1, center, p2, 20_f64.to_radians());
constraints::PointPointDistance::create(&mut s, p1, p2, 15.);
```

We could also have methods like `elements::Line::create_through_points(&mut s, p1, p2)`.