### PR TITLE
Init Fiksi SVG renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,6 +444,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiksi_svg"
+version = "0.1.0"
+dependencies = [
+ "color",
+ "fiksi",
+]
+
+[[package]]
+name = "fiksi_svg_tests"
+version = "0.1.0"
+dependencies = [
+ "fiksi",
+ "fiksi_svg",
+]
+
+[[package]]
 name = "fiksi_toy"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,11 @@
 [workspace]
 resolver = "2"
-members = ["fiksi", "examples/fiksi_toy"]
+members = [
+  "fiksi",
+  "fiksi_svg",
+  "examples/fiksi_svg_tests",
+  "examples/fiksi_toy",
+]
 
 [workspace.package]
 # Fiksi version, also used by other packages which want to mimic Fiksi's version.
@@ -18,6 +23,7 @@ repository = "https://github.com/endoli/fiksi"
 
 [workspace.dependencies]
 fiksi = { version = "0.1.0", path = "fiksi", default-features = false }
+fiksi_svg = { version = "0.1.0", path = "fiksi_svg", default-features = false }
 
 tracing = { version = "0.1.41", default-features = false, features = ["attributes", "log"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/examples/fiksi_svg_tests/Cargo.toml
+++ b/examples/fiksi_svg_tests/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fiksi_svg_tests"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+fiksi = { workspace = true, features = ["std"] }
+fiksi_svg = { workspace = true, features = ["std"] }
+
+[lints]
+workspace = true

--- a/examples/fiksi_svg_tests/src/main.rs
+++ b/examples/fiksi_svg_tests/src/main.rs
@@ -1,0 +1,64 @@
+// Copyright 2025 the Fiksi Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! An example using the Fiksi SVG builder.
+
+use fiksi::{System, constraints, elements};
+use fiksi_svg::{SvgBuilder, color};
+
+fn main() {
+    let mut system = System::new();
+    let mut builder = SvgBuilder::new();
+
+    let p1 = elements::Point::create(&mut system, 10., 0.);
+    let p2 = elements::Point::create(&mut system, 20., 10.);
+    let p3 = elements::Point::create(&mut system, 30., -10.);
+    let p4 = elements::Point::create(&mut system, -40., -50.);
+    let p5 = elements::Point::create(&mut system, 40., -50.);
+
+    // Configure points `(p1, p2, p3)` into a triangle with two given angles and one given side
+    // length.
+    constraints::PointPointPointAngle::create(&mut system, p1, p2, p3, 40_f64.to_radians());
+    constraints::PointPointPointAngle::create(&mut system, p2, p3, p1, 70_f64.to_radians());
+    constraints::PointPointDistance::create(&mut system, p1, p2, 70.);
+
+    let triangle_side1 = elements::Line::create(&mut system, p1, p2);
+    let triangle_side2 = elements::Line::create(&mut system, p2, p3);
+    let triangle_side3 = elements::Line::create(&mut system, p1, p3);
+
+    // A circle coincident with one of the triangle corners.
+    let circle = elements::Circle::create(&mut system, p3, 5.);
+    // The (boundless) line representing the opposite triangle side must be tangent on the circle.
+    constraints::LineCircleTangency::create(&mut system, triangle_side1, circle);
+
+    // A line.
+    let line = elements::Line::create(&mut system, p4, p5);
+    // There must be a (counterclockwise) 90 degree angle from one of the triangle sides to the
+    // start of the line.
+    constraints::LineLineAngle::create(&mut system, triangle_side3, line, -90_f64.to_radians());
+
+    // The circle's center (also one of the triangle corners) must be incident on the line.
+    constraints::PointLineIncidence::create(&mut system, p3, line);
+    // One of the line's points must be a given distance from the circle center, and the line's
+    // points must be a given distance from each other.
+    constraints::PointPointDistance::create(&mut system, p3, p4, 40.);
+    constraints::PointPointDistance::create(&mut system, p4, p5, 80.);
+
+    for el in [triangle_side1, triangle_side2, triangle_side3] {
+        builder.set_element_color(
+            el,
+            color::AlphaColor::<color::Oklch>::new([0.5, 0.1, 0., 1.]),
+        );
+    }
+    builder.set_element_color(
+        line,
+        color::AlphaColor::<color::Oklch>::new([0.5, 0.1, 80., 1.]),
+    );
+    builder.set_element_color(
+        circle,
+        color::AlphaColor::<color::Oklch>::new([0.5, 0.1, 160., 1.]),
+    );
+    system.solve(None, fiksi::SolvingOptions::DEFAULT);
+    builder.add_system_snapshot(&system);
+    println!("{}", builder.finish());
+}

--- a/fiksi/src/elements/mod.rs
+++ b/fiksi/src/elements/mod.rs
@@ -85,6 +85,13 @@ pub(crate) mod element {
             Self { system_id, id, tag }
         }
 
+        /// Get the handle as an opaque numeric identifier.
+        ///
+        /// These are unique across systems, but there is no other meaning associated with them.
+        pub fn as_id(&self) -> u64 {
+            u64::from(self.system_id) << 32 + u64::from(self.id)
+        }
+
         /// Get the value of the element.
         pub fn get_value(&self, system: &System) -> ElementValue {
             // TODO: return `Result` instead of panicking?

--- a/fiksi_svg/Cargo.toml
+++ b/fiksi_svg/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "fiksi_svg"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+fiksi = { workspace = true, features = ["std"] }
+
+color = "0.3.1"
+
+[features]
+default = ["std"]
+std = ["fiksi/std"]
+
+[lints]
+workspace = true

--- a/fiksi_svg/src/lib.rs
+++ b/fiksi_svg/src/lib.rs
@@ -1,0 +1,103 @@
+// Copyright 2025 the Fiksi Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! This renders Fiksi systems to an SVG.
+
+// LINEBENDER LINT SET - lib.rs - v3
+// See https://linebender.org/wiki/canonical-lints/
+// These lints shouldn't apply to examples or tests.
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+// These lints shouldn't apply to examples.
+#![warn(clippy::print_stdout, clippy::print_stderr)]
+// Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
+#![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
+// END LINEBENDER LINT SET
+
+use std::{collections::HashMap, fmt::Write};
+
+pub use color;
+pub use fiksi;
+
+use color::{AlphaColor, ColorSpace, Rgba8, Srgb};
+use fiksi::{AnyElementHandle, Element, ElementHandle, System};
+
+const DEFAULT_ELEMENT_COLOR: Rgba8 = Rgba8::from_u8_array([0, 0, 0, u8::MAX]);
+
+/// An SVG builder for rendering [Fiksi systems](System) into an SVG.
+#[derive(Debug)]
+pub struct SvgBuilder {
+    svg: String,
+    colors: HashMap<AnyElementHandle, Rgba8>,
+}
+
+impl SvgBuilder {
+    /// Construct a new SVG builder, to build an SVG from [Fiksi systems](System).
+    pub fn new() -> Self {
+        Self {
+            svg: r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="-100 -100 200 200">"#.into(),
+            colors: HashMap::new(),
+        }
+    }
+
+    /// Set the draw color of an element.
+    pub fn set_element_color<T: Element, CS: ColorSpace>(
+        &mut self,
+        element: ElementHandle<T>,
+        color: AlphaColor<CS>,
+    ) {
+        let srgb = color.convert::<Srgb>().to_rgba8();
+        self.colors.insert(element.as_any_element(), srgb);
+    }
+
+    /// Render the elements of the [Fiksi system](System) to the SVG.
+    pub fn add_system_snapshot(&mut self, system: &System) {
+        use fiksi::ElementValue;
+        for handle in system.get_element_handles() {
+            match handle.get_value(system) {
+                ElementValue::Point(point) => {
+                    let color = self.colors.get(&handle).unwrap_or(&DEFAULT_ELEMENT_COLOR);
+
+                    write!(
+                        &mut self.svg,
+                        r#"<circle cx="{}" cy="{}" r="1" fill="{color:0X}" id="point-{}"/>"#,
+                        point.x,
+                        point.y,
+                        handle.as_id()
+                    )
+                    .unwrap();
+                }
+                ElementValue::Line(line) => {
+                    let color = self.colors.get(&handle).unwrap_or(&DEFAULT_ELEMENT_COLOR);
+
+                    write!(
+                        &mut self.svg,
+                        r#"<line x1="{}" y1="{}" x2="{}" y2="{}" stroke="{color:0X}" id="line-{}"/>"#,
+                        line.p0.x,
+                        line.p0.y,
+                        line.p1.x,
+                        line.p1.y,
+                        handle.as_id()
+                    ).unwrap();
+                }
+                ElementValue::Circle(circle) => {
+                    let color = self.colors.get(&handle).unwrap_or(&DEFAULT_ELEMENT_COLOR);
+
+                    write!(
+                        &mut self.svg,
+                        r#"<circle cx="{}" cy="{}" r="{}" stroke="{color:0X}" fill="none" id="circle-{}"/>"#,
+                        circle.center.x,
+                        circle.center.y,
+                        circle.radius,
+                        handle.as_id()
+                    ).unwrap();
+                }
+            }
+        }
+    }
+
+    /// Get the SVG.
+    pub fn finish(mut self) -> String {
+        write!(&mut self.svg, "</svg>").unwrap();
+        self.svg
+    }
+}


### PR DESCRIPTION
This is a bit limited still. Run an example with the following.

```bash
cargo run -p fiksi_svg_tests > example.svg
```