### PR TITLE
Add hash-based collections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,9 +438,12 @@ dependencies = [
 name = "fiksi"
 version = "0.1.0"
 dependencies = [
+ "hashbrown",
+ "indexmap",
  "kurbo",
  "libm",
  "nalgebra",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -658,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
 ]
@@ -685,9 +688,9 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -931,7 +934,7 @@ dependencies = [
  "hexf-parse",
  "indexmap",
  "log",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "spirv",
  "strum",
  "termcolor",
@@ -1591,6 +1594,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -2395,7 +2404,7 @@ dependencies = [
  "parking_lot",
  "profiling",
  "raw-window-handle",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.12",
  "wgpu-hal",
@@ -2438,7 +2447,7 @@ dependencies = [
  "range-alloc",
  "raw-window-handle",
  "renderdoc-sys",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.12",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,7 +443,6 @@ dependencies = [
  "kurbo",
  "libm",
  "nalgebra",
- "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -934,7 +933,7 @@ dependencies = [
  "hexf-parse",
  "indexmap",
  "log",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "spirv",
  "strum",
  "termcolor",
@@ -1594,12 +1593,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -2404,7 +2397,7 @@ dependencies = [
  "parking_lot",
  "profiling",
  "raw-window-handle",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "smallvec",
  "thiserror 2.0.12",
  "wgpu-hal",
@@ -2447,7 +2440,7 @@ dependencies = [
  "range-alloc",
  "raw-window-handle",
  "renderdoc-sys",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "smallvec",
  "thiserror 2.0.12",
  "wasm-bindgen",

--- a/fiksi/Cargo.toml
+++ b/fiksi/Cargo.toml
@@ -21,7 +21,10 @@ std = ["kurbo/std", "nalgebra/std"]
 libm = ["dep:libm", "kurbo/libm", "nalgebra/libm"]
 
 [dependencies]
+hashbrown = { version = "0.15.5", default-features = false }
+indexmap = { version = "2.10.0", default-features = false }
 kurbo = { version = "0.11.2", default-features = false }
+rustc-hash = { version = "2.1.1", default-features = false }
 
 # Temporarily included
 nalgebra = { version = "0.33.2", default-features = false, features = ["alloc"] }

--- a/fiksi/Cargo.toml
+++ b/fiksi/Cargo.toml
@@ -21,10 +21,9 @@ std = ["kurbo/std", "nalgebra/std"]
 libm = ["dep:libm", "kurbo/libm", "nalgebra/libm"]
 
 [dependencies]
-hashbrown = { version = "0.15.5", default-features = false }
+hashbrown = { version = "0.15.5", default-features = false, features = ["default-hasher"] }
 indexmap = { version = "2.10.0", default-features = false }
 kurbo = { version = "0.11.2", default-features = false }
-rustc-hash = { version = "2.1.1", default-features = false }
 
 # Temporarily included
 nalgebra = { version = "0.33.2", default-features = false, features = ["alloc"] }

--- a/fiksi/src/collections.rs
+++ b/fiksi/src/collections.rs
@@ -1,0 +1,69 @@
+// Copyright 2025 the Fiksi Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! This implements some hash-based collections backed by [`rustc_hash::FxBuildHasher`]. That
+//! project states:
+//!
+//! "A speedy hash algorithm for use within rustc. The hashmap in liballoc by default uses
+//! `SipHash` which isn’t quite as speedy as we want. In the compiler we’re not really worried
+//! about DOS attempts, so we use a fast non-cryptographic hash."
+//!
+//! Here we have a similar use-case: our keys are very small and sequential. We're not too worried
+//! about DOS attempts. Users can control which keys are masked out, but not the keys themselves.
+//! We do we still want to get a reasonably good hash distribution in cases where there is a
+//! pattern in how keys are masked out (meaning we can't just use "identity hashing").
+
+use rustc_hash::FxBuildHasher;
+
+/// Type-alias for a [`hashbrown::HashMap`] backed by a [`rustc_hash::FxHasher`].
+///
+/// See the [module-level](self) documentation for information about the hash function used.
+pub(crate) type FxHashMap<K, V> = hashbrown::HashMap<K, V, FxBuildHasher>;
+
+/// Type-alias for a [`hashbrown::HashSet`] backed by a [`rustc_hash::FxHasher`].
+///
+/// See the [module-level](self) documentation for information about the hash function used.
+pub(crate) type FxHashSet<K> = hashbrown::HashSet<K, FxBuildHasher>;
+
+/// Type-alias for a [`indexmap::IndexMap`] backed by a [`rustc_hash::FxHasher`].
+///
+/// See the [module-level](self) documentation for information about the hash function used.
+pub(crate) type FxIndexMap<K, V> = indexmap::IndexMap<K, V, FxBuildHasher>;
+
+/// Type-alias for a [`indexmap::IndexSet`] backed by a [`rustc_hash::FxHasher`].
+///
+/// See the [module-level](self) documentation for information about the hash function used.
+pub(crate) type FxIndexSet<K> = indexmap::IndexSet<K, FxBuildHasher>;
+
+/// An extension trait to be able to define some methods on type-aliased collections.
+pub(crate) trait CollectionExt: Sized {
+    fn new() -> Self {
+        Self::with_capacity(0)
+    }
+
+    fn with_capacity(n: usize) -> Self;
+}
+
+impl<K, V> CollectionExt for FxHashMap<K, V> {
+    fn with_capacity(n: usize) -> Self {
+        Self::with_capacity_and_hasher(n, <_>::default())
+    }
+}
+
+impl<K> CollectionExt for FxHashSet<K> {
+    fn with_capacity(n: usize) -> Self {
+        Self::with_capacity_and_hasher(n, <_>::default())
+    }
+}
+
+impl<K, V> CollectionExt for FxIndexMap<K, V> {
+    fn with_capacity(n: usize) -> Self {
+        Self::with_capacity_and_hasher(n, <_>::default())
+    }
+}
+
+impl<K> CollectionExt for FxIndexSet<K> {
+    fn with_capacity(n: usize) -> Self {
+        Self::with_capacity_and_hasher(n, <_>::default())
+    }
+}

--- a/fiksi/src/collections.rs
+++ b/fiksi/src/collections.rs
@@ -1,39 +1,32 @@
 // Copyright 2025 the Fiksi Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! This implements some hash-based collections backed by [`rustc_hash::FxBuildHasher`]. That
-//! project states:
+//! This implements some hash-based collections backed by [`hashbrown::DefaultHashBuilder`], which
+//! (as of this writing) is a re-export for [`foldhash::fast::RandomState`][foldhash]. The
+//! `foldhash` project states:
 //!
-//! "A speedy hash algorithm for use within rustc. The hashmap in liballoc by default uses
-//! `SipHash` which isn’t quite as speedy as we want. In the compiler we’re not really worried
-//! about DOS attempts, so we use a fast non-cryptographic hash."
+//! "This crate provides foldhash, a fast, non-cryptographic, minimally DoS-resistant hashing
+//! algorithm designed for computational uses such as hashmaps, bloom filters, count sketching,
+//! etc."
 //!
-//! Here we have a similar use-case: our keys are very small and sequential. We're not too worried
-//! about DOS attempts. Users can control which keys are masked out, but not the keys themselves.
-//! We do we still want to get a reasonably good hash distribution in cases where there is a
-//! pattern in how keys are masked out (meaning we can't just use "identity hashing").
+//! In our use-case, our keys are very small and sequential. We're not too worried about DOS
+//! attempts. Users can control which keys are masked out, but not the keys themselves. We do we
+//! still want to get a reasonably good hash distribution in cases where there is a pattern in how
+//! keys are masked out (meaning we can't just use "identity hashing").
+//!
+//! For hashing small numeric keys, foldhash optimizes to just a few instructions.
+//!
+//! [foldhash]: <https://docs.rs/foldhash/0.1.2/foldhash/fast/struct.RandomState.html>
 
-use rustc_hash::FxBuildHasher;
-
-/// Type-alias for a [`hashbrown::HashMap`] backed by a [`rustc_hash::FxHasher`].
+/// Type-alias for a [`indexmap::IndexMap`] backed by a [`hashbrown::DefaultHashBuilder`].
 ///
 /// See the [module-level](self) documentation for information about the hash function used.
-pub(crate) type FxHashMap<K, V> = hashbrown::HashMap<K, V, FxBuildHasher>;
+pub(crate) type IndexMap<K, V> = indexmap::IndexMap<K, V, hashbrown::DefaultHashBuilder>;
 
-/// Type-alias for a [`hashbrown::HashSet`] backed by a [`rustc_hash::FxHasher`].
+/// Type-alias for a [`indexmap::IndexSet`] backed by a [`hashbrown::DefaultHashBuilder`].
 ///
 /// See the [module-level](self) documentation for information about the hash function used.
-pub(crate) type FxHashSet<K> = hashbrown::HashSet<K, FxBuildHasher>;
-
-/// Type-alias for a [`indexmap::IndexMap`] backed by a [`rustc_hash::FxHasher`].
-///
-/// See the [module-level](self) documentation for information about the hash function used.
-pub(crate) type FxIndexMap<K, V> = indexmap::IndexMap<K, V, FxBuildHasher>;
-
-/// Type-alias for a [`indexmap::IndexSet`] backed by a [`rustc_hash::FxHasher`].
-///
-/// See the [module-level](self) documentation for information about the hash function used.
-pub(crate) type FxIndexSet<K> = indexmap::IndexSet<K, FxBuildHasher>;
+pub(crate) type IndexSet<K> = indexmap::IndexSet<K, hashbrown::DefaultHashBuilder>;
 
 /// An extension trait to be able to define some methods on type-aliased collections.
 pub(crate) trait CollectionExt: Sized {
@@ -44,25 +37,13 @@ pub(crate) trait CollectionExt: Sized {
     fn with_capacity(n: usize) -> Self;
 }
 
-impl<K, V> CollectionExt for FxHashMap<K, V> {
+impl<K, V> CollectionExt for IndexMap<K, V> {
     fn with_capacity(n: usize) -> Self {
         Self::with_capacity_and_hasher(n, <_>::default())
     }
 }
 
-impl<K> CollectionExt for FxHashSet<K> {
-    fn with_capacity(n: usize) -> Self {
-        Self::with_capacity_and_hasher(n, <_>::default())
-    }
-}
-
-impl<K, V> CollectionExt for FxIndexMap<K, V> {
-    fn with_capacity(n: usize) -> Self {
-        Self::with_capacity_and_hasher(n, <_>::default())
-    }
-}
-
-impl<K> CollectionExt for FxIndexSet<K> {
+impl<K> CollectionExt for IndexSet<K> {
     fn with_capacity(n: usize) -> Self {
         Self::with_capacity_and_hasher(n, <_>::default())
     }

--- a/fiksi/src/lib.rs
+++ b/fiksi/src/lib.rs
@@ -76,6 +76,7 @@ pub use kurbo;
 pub mod manual;
 
 mod analyze;
+pub(crate) mod collections;
 pub mod constraints;
 pub mod elements;
 pub(crate) mod graph;

--- a/fiksi/src/subsystem.rs
+++ b/fiksi/src/subsystem.rs
@@ -3,7 +3,7 @@
 
 use alloc::vec::Vec;
 
-use crate::{Expression, collections::FxIndexSet};
+use crate::{Expression, collections::IndexSet};
 
 pub(crate) struct Subsystem<'s> {
     /// All expressions in the [`crate::System`] this subsystem belongs to.
@@ -15,7 +15,7 @@ pub(crate) struct Subsystem<'s> {
 
     /// The free variables that are part of this subsystem. These are indices into the system's
     /// variable slice.
-    free_variables: FxIndexSet<u32>,
+    free_variables: IndexSet<u32>,
 }
 
 impl<'s> Subsystem<'s> {

--- a/fiksi/src/subsystem.rs
+++ b/fiksi/src/subsystem.rs
@@ -1,9 +1,9 @@
 // Copyright 2025 the Fiksi Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use alloc::{collections::btree_map::BTreeMap, vec::Vec};
+use alloc::vec::Vec;
 
-use crate::Expression;
+use crate::{Expression, collections::FxIndexSet};
 
 pub(crate) struct Subsystem<'s> {
     /// All expressions in the [`crate::System`] this subsystem belongs to.
@@ -13,34 +13,21 @@ pub(crate) struct Subsystem<'s> {
     /// [`Self::all_expressions`].
     expressions: Vec<u32>,
 
-    /// The indices of free variables.
-    free_variables: Vec<u32>,
-
-    /// Map from variable indices to free variable index.
-    variable_to_free_variable: BTreeMap<u32, u32>,
+    /// The free variables that are part of this subsystem. These are indices into the system's
+    /// variable slice.
+    free_variables: FxIndexSet<u32>,
 }
 
 impl<'s> Subsystem<'s> {
     pub(crate) fn new(
         all_expressions: &'s [Expression],
-        mut free_variables: Vec<u32>,
+        free_variables: impl IntoIterator<Item = u32>,
         expressions: Vec<u32>,
     ) -> Self {
-        free_variables.sort_unstable();
-
-        let mut variable_to_free_variable = alloc::collections::BTreeMap::new();
-        for (idx, &free_variable) in free_variables.iter().enumerate() {
-            variable_to_free_variable.insert(
-                free_variable,
-                idx.try_into().expect("less than 2^32 elements"),
-            );
-        }
-
         Self {
             all_expressions,
-            free_variables,
-            variable_to_free_variable,
             expressions,
+            free_variables: free_variables.into_iter().collect(),
         }
     }
 }
@@ -66,6 +53,12 @@ impl Subsystem<'_> {
 
     #[inline(always)]
     pub(crate) fn free_variable_index(&self, variable: u32) -> Option<u32> {
-        self.variable_to_free_variable.get(&variable).copied()
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "We don't allow this many variables."
+        )]
+        self.free_variables
+            .get_index_of(&variable)
+            .map(|idx| idx as u32)
     }
 }


### PR DESCRIPTION
These collections get used in a follow-up PR.

In the current PR, one of these collections gets used to rewrite `Subsystem` to use a single collection for its free variable bookkeeping.