### PR TITLE
Allow updating element values

### DIFF
--- a/fiksi/src/elements/mod.rs
+++ b/fiksi/src/elements/mod.rs
@@ -470,3 +470,26 @@ impl Element for Line {
 impl Element for Circle {
     type Output = kurbo::Circle;
 }
+
+impl ElementHandle<Point> {
+    /// Update the coordinates of this point element.
+    pub fn update_value(self, system: &mut System, x: f64, y: f64) {
+        let EncodedElement::Point { idx } = &system.elements[self.id as usize] else {
+            unreachable!()
+        };
+
+        system.variables[*idx as usize] = x;
+        system.variables[*idx as usize + 1] = y;
+    }
+}
+
+impl ElementHandle<Length> {
+    /// Update the value of this length element.
+    pub fn update_value(self, system: &mut System, length: f64) {
+        let EncodedElement::Length { idx } = &system.elements[self.id as usize] else {
+            unreachable!()
+        };
+
+        system.variables[*idx as usize] = length;
+    }
+}


### PR DESCRIPTION
This is the element counterpart of https://github.com/endoli/fiksi/pull/78.

Closes https://github.com/endoli/fiksi/issues/59.

This doesn't do `Line` or `Circle`, as those reference `Point` and `Length`. Perhaps we want to be able to update those directly too, but then we'd probably want to be able to construct them directly from values as well (creating and perhaps returning the necessary `Point`s and `Length`s automatically).