### PR TITLE
Add line-line perpendicularity constraint

### DIFF
--- a/fiksi/src/constraints/expressions.rs
+++ b/fiksi/src/constraints/expressions.rs
@@ -1172,16 +1172,7 @@ impl LineLineOrthogonality {
 
         let residual = v.dot(u);
 
-        let gradient = [
-            -v.x,
-            -v.y,
-            v.x,
-            v.y,
-            -u.x,
-            -u.y,
-            u.x,
-            u.y,
-        ];
+        let gradient = [-v.x, -v.y, v.x, v.y, -u.x, -u.y, u.x, u.y];
 
         (residual, gradient)
     }

--- a/fiksi/src/constraints/expressions.rs
+++ b/fiksi/src/constraints/expressions.rs
@@ -31,8 +31,8 @@ pub(crate) enum Expression {
     PointCircleIncidence(PointCircleIncidence),
     SegmentSegmentLengthEquality(SegmentSegmentLengthEquality),
     LineLineAngle(LineLineAngle),
-    LineLineOrthogonality(LineLineOrthogonality),
     LineLineParallelism(LineLineParallelism),
+    LineLinePerpendicularity(LineLinePerpendicularity),
     LineCircleTangency(LineCircleTangency),
 }
 
@@ -134,7 +134,7 @@ impl Expression {
                 variables[..v.len()].copy_from_slice(&v);
                 &mut variables[..v.len()]
             }
-            Self::LineLineOrthogonality(e) => {
+            Self::LineLineParallelism(e) => {
                 let v = [
                     e.line1_point1_idx,
                     e.line1_point1_idx + 1,
@@ -148,7 +148,7 @@ impl Expression {
                 variables[..v.len()].copy_from_slice(&v);
                 &mut variables[..v.len()]
             }
-            Self::LineLineParallelism(e) => {
+            Self::LineLinePerpendicularity(e) => {
                 let v = [
                     e.line1_point1_idx,
                     e.line1_point1_idx + 1,
@@ -1132,21 +1132,21 @@ impl LineLineParallelism {
     }
 }
 
-/// Constrain two lines to be orthogonal to each other.
-pub(crate) struct LineLineOrthogonality {
+/// Constrain two lines to be perpendicular to each other.
+pub(crate) struct LineLinePerpendicularity {
     pub(crate) line1_point1_idx: u32,
     pub(crate) line1_point2_idx: u32,
     pub(crate) line2_point1_idx: u32,
     pub(crate) line2_point2_idx: u32,
 }
 
-impl From<LineLineOrthogonality> for Expression {
-    fn from(expression: LineLineOrthogonality) -> Self {
-        Self::LineLineOrthogonality(expression)
+impl From<LineLinePerpendicularity> for Expression {
+    fn from(expression: LineLinePerpendicularity) -> Self {
+        Self::LineLinePerpendicularity(expression)
     }
 }
 
-impl LineLineOrthogonality {
+impl LineLinePerpendicularity {
     /// See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
     #[inline(always)]
     fn compute_residual_and_gradient_(variables: &[f64; 8]) -> (f64, [f64; 8]) {
@@ -1637,9 +1637,9 @@ mod tests {
     }
 
     #[test]
-    fn line_line_orthogonality_first_finite_difference() {
+    fn line_line_perpendicularity_first_finite_difference() {
         test_first_finite_difference(
-            LineLineOrthogonality::compute_residual_and_gradient_,
+            LineLinePerpendicularity::compute_residual_and_gradient_,
             |variables, delta| {
                 (
                     variables.map(|d| (d - 0.5) * 1e0),
@@ -1648,7 +1648,7 @@ mod tests {
             },
         );
         test_first_finite_difference(
-            LineLineOrthogonality::compute_residual_and_gradient_,
+            LineLinePerpendicularity::compute_residual_and_gradient_,
             |variables, delta| {
                 (
                     variables.map(|d| (d - 0.5) * 1e-10),

--- a/fiksi/src/constraints/mod.rs
+++ b/fiksi/src/constraints/mod.rs
@@ -48,8 +48,8 @@ pub(crate) mod constraint {
         /// A handle to a [`LineLineParallelism`](super::LineLineParallelism) constraint.
         LineLineParallelism(ConstraintHandle<super::LineLineParallelism>),
 
-        /// A handle to a [`LineLineOrthogonality`](super::LineLineOrthogonality) constraint.
-        LineLineOrthogonality(ConstraintHandle<super::LineLineOrthogonality>),
+        /// A handle to a [`LineLinePerpendicularity`](super::LineLinePerpendicularity) constraint.
+        LineLinePerpendicularity(ConstraintHandle<super::LineLinePerpendicularity>),
 
         /// A handle to a [`LineCircleTangency`](super::LineCircleTangency) constraint.
         LineCircleTangency(ConstraintHandle<super::LineCircleTangency>),
@@ -199,8 +199,8 @@ pub(crate) mod constraint {
                 ConstraintTag::LineLineParallelism => TaggedConstraintHandle::LineLineParallelism(
                     ConstraintHandle::from_ids(self.system_id, self.id),
                 ),
-                ConstraintTag::LineLineOrthogonality => {
-                    TaggedConstraintHandle::LineLineOrthogonality(ConstraintHandle::from_ids(
+                ConstraintTag::LineLinePerpendicularity => {
+                    TaggedConstraintHandle::LineLinePerpendicularity(ConstraintHandle::from_ids(
                         self.system_id,
                         self.id,
                     ))
@@ -775,17 +775,17 @@ impl LineLineParallelism {
     }
 }
 
-/// Constrain two lines to be orthogonal to each other.
-pub struct LineLineOrthogonality {}
+/// Constrain two lines to be perpenpdicular to each other.
+pub struct LineLinePerpendicularity {}
 
-impl sealed::ConstraintInner for LineLineOrthogonality {
+impl sealed::ConstraintInner for LineLinePerpendicularity {
     fn tag() -> ConstraintTag {
-        ConstraintTag::LineLineOrthogonality
+        ConstraintTag::LineLinePerpendicularity
     }
 }
 
-impl LineLineOrthogonality {
-    /// Construct a constraint between two lines to be orthogonal to each other.
+impl LineLinePerpendicularity {
+    /// Construct a constraint between two lines to be perpendicular to each other.
     pub fn create(
         system: &mut System,
         line1: ElementHandle<elements::Line>,
@@ -816,8 +816,8 @@ impl LineLineOrthogonality {
             ]),
         );
         system.add_constraint(
-            ConstraintTag::LineLineOrthogonality,
-            [expressions::LineLineOrthogonality {
+            ConstraintTag::LineLinePerpendicularity,
+            [expressions::LineLinePerpendicularity {
                 line1_point1_idx,
                 line1_point2_idx,
                 line2_point1_idx,
@@ -894,7 +894,7 @@ pub(crate) enum ConstraintTag {
     SegmentSegmentLengthEquality,
     LineLineAngle,
     LineLineParallelism,
-    LineLineOrthogonality,
+    LineLinePerpendicularity,
     LineCircleTangency,
 }
 
@@ -910,7 +910,7 @@ impl ConstraintTag {
             Self::SegmentSegmentLengthEquality => SegmentSegmentLengthEquality::VALENCY,
             Self::LineLineAngle => LineLineAngle::VALENCY,
             Self::LineLineParallelism => LineLineParallelism::VALENCY,
-            Self::LineLineOrthogonality => LineLineOrthogonality::VALENCY,
+            Self::LineLinePerpendicularity => LineLinePerpendicularity::VALENCY,
             Self::LineCircleTangency => LineCircleTangency::VALENCY,
         }
     }
@@ -972,7 +972,7 @@ impl Constraint for LineLineParallelism {
     const VALENCY: u8 = 1;
 }
 
-impl Constraint for LineLineOrthogonality {
+impl Constraint for LineLinePerpendicularity {
     const VALENCY: u8 = 1;
 }
 

--- a/fiksi/src/utils.rs
+++ b/fiksi/src/utils.rs
@@ -21,8 +21,8 @@ pub(crate) fn calculate_residual(expression: &Expression, variables: &[f64]) -> 
         }
         Expression::LineCircleTangency(expression) => expression.compute_residual(variables),
         Expression::LineLineAngle(expression) => expression.compute_residual(variables),
-        Expression::LineLineOrthogonality(expression) => expression.compute_residual(variables),
         Expression::LineLineParallelism(expression) => expression.compute_residual(variables),
+        Expression::LineLinePerpendicularity(expression) => expression.compute_residual(variables),
     }
 }
 
@@ -136,7 +136,7 @@ pub(crate) fn calculate_residuals_and_jacobian(
                         ..(expression_idx + 1) * num_free_variables],
                 );
             }
-            Expression::LineLineOrthogonality(expression) => {
+            Expression::LineLineParallelism(expression) => {
                 expression.compute_residual_and_gradient(
                     subsystem,
                     variables,
@@ -145,7 +145,7 @@ pub(crate) fn calculate_residuals_and_jacobian(
                         ..(expression_idx + 1) * num_free_variables],
                 );
             }
-            Expression::LineLineParallelism(expression) => {
+            Expression::LineLinePerpendicularity(expression) => {
                 expression.compute_residual_and_gradient(
                     subsystem,
                     variables,

--- a/fiksi/src/utils.rs
+++ b/fiksi/src/utils.rs
@@ -21,6 +21,7 @@ pub(crate) fn calculate_residual(expression: &Expression, variables: &[f64]) -> 
         }
         Expression::LineCircleTangency(expression) => expression.compute_residual(variables),
         Expression::LineLineAngle(expression) => expression.compute_residual(variables),
+        Expression::LineLineOrthogonality(expression) => expression.compute_residual(variables),
         Expression::LineLineParallelism(expression) => expression.compute_residual(variables),
     }
 }
@@ -127,6 +128,15 @@ pub(crate) fn calculate_residuals_and_jacobian(
                 );
             }
             Expression::LineLineAngle(expression) => {
+                expression.compute_residual_and_gradient(
+                    subsystem,
+                    variables,
+                    &mut residuals[expression_idx],
+                    &mut jacobian[expression_idx * num_free_variables
+                        ..(expression_idx + 1) * num_free_variables],
+                );
+            }
+            Expression::LineLineOrthogonality(expression) => {
                 expression.compute_residual_and_gradient(
                     subsystem,
                     variables,


### PR DESCRIPTION
The counterpart of https://github.com/endoli/fiksi/pull/17.

(These are the singular/non-dimensional versions of the line-line angle constraint, and therefore numerically simpler.)