### PR TITLE
Make `VariableMap` a trait

### DIFF
--- a/fiksi/src/analyze/numerical/mod.rs
+++ b/fiksi/src/analyze/numerical/mod.rs
@@ -5,10 +5,7 @@ use alloc::{vec, vec::Vec};
 
 use nalgebra::DMatrix;
 
-use crate::{
-    AnyConstraintHandle, System,
-    variable_map::IdentityFreeVariableMap,
-};
+use crate::{AnyConstraintHandle, System, variable_map::IdentityFreeVariableMap};
 
 const EPSILON: f64 = 1e-8;
 

--- a/fiksi/src/analyze/numerical/mod.rs
+++ b/fiksi/src/analyze/numerical/mod.rs
@@ -5,7 +5,10 @@ use alloc::{vec, vec::Vec};
 
 use nalgebra::DMatrix;
 
-use crate::{AnyConstraintHandle, System, VariableMap, collections::IndexSet};
+use crate::{
+    AnyConstraintHandle, System,
+    variable_map::IdentityFreeVariableMap,
+};
 
 const EPSILON: f64 = 1e-8;
 
@@ -122,14 +125,8 @@ pub(crate) fn find_overconstraints(system: &System) -> Vec<AnyConstraintHandle> 
     let mut jacobian = vec![0.; system.expressions.len() * system.variables.len()];
 
     // All variables are free.
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "We don't allow this many variables."
-    )]
-    let variable_map = VariableMap {
-        free_variables: &IndexSet::from_iter(0..system.variables.len() as u32),
+    let variable_map = IdentityFreeVariableMap {
         variable_values: &system.variables,
-        free_variable_values: &system.variables,
     };
     for (row, expression) in system.expressions.iter().enumerate() {
         let gradient =

--- a/fiksi/src/analyze/numerical/mod.rs
+++ b/fiksi/src/analyze/numerical/mod.rs
@@ -5,7 +5,7 @@ use alloc::{vec, vec::Vec};
 
 use nalgebra::DMatrix;
 
-use crate::{AnyConstraintHandle, System, variable_map::IdentityFreeVariableMap};
+use crate::{AnyConstraintHandle, System, variable_map::IdentityVariableMap};
 
 const EPSILON: f64 = 1e-8;
 
@@ -122,7 +122,7 @@ pub(crate) fn find_overconstraints(system: &System) -> Vec<AnyConstraintHandle> 
     let mut jacobian = vec![0.; system.expressions.len() * system.variables.len()];
 
     // All variables are free.
-    let variable_map = IdentityFreeVariableMap {
+    let variable_map = IdentityVariableMap {
         variable_values: &system.variables,
     };
     for (row, expression) in system.expressions.iter().enumerate() {

--- a/fiksi/src/constraints/expressions.rs
+++ b/fiksi/src/constraints/expressions.rs
@@ -772,7 +772,7 @@ fn reslice<const N: usize, const M: usize>(slice: &[f64; M]) -> &[f64; N] {
 }
 
 impl Expression {
-    pub(crate) fn calculate_residual(&self, variable_map: VariableMap<'_>) -> f64 {
+    pub(crate) fn calculate_residual(&self, variable_map: impl VariableMap) -> f64 {
         // Buffer to get variable indices of this expression.
         let mut variable_indices = [0_u32; 8];
 
@@ -787,7 +787,7 @@ impl Expression {
             .iter()
             .enumerate()
         {
-            match variable_map.get_variable(variable_idx) {
+            match variable_map.get_value(variable_idx) {
                 Variable::Free { value, idx: _ } => {
                     variable_values[i] = value;
                 }
@@ -853,7 +853,7 @@ impl Expression {
     }
     pub(crate) fn calculate_residual_and_gradient(
         &self,
-        variable_map: VariableMap<'_>,
+        variable_map: impl VariableMap,
         gradient: &mut [f64],
     ) -> f64 {
         // Buffer to get variable indices of this expression.
@@ -871,7 +871,7 @@ impl Expression {
             .iter()
             .enumerate()
         {
-            match variable_map.get_variable(variable_idx) {
+            match variable_map.get_value(variable_idx) {
                 Variable::Free { value, idx } => {
                     variable_values[i] = value;
                     free_variable_indices[i] = Some(idx);

--- a/fiksi/src/constraints/mod.rs
+++ b/fiksi/src/constraints/mod.rs
@@ -93,7 +93,6 @@ pub(crate) mod constraint {
             );
 
             let constraint = &system.constraints[self.id as usize];
-            // An empty variable map.
             let variable_map = IdentityFixedVariableMap {
                 variable_values: &system.variables,
             };
@@ -152,7 +151,6 @@ pub(crate) mod constraint {
             let valency = self.tag.valency();
             let constraint = &system.constraints[self.id as usize];
 
-            // An empty variable map.
             let variable_map = IdentityFixedVariableMap {
                 variable_values: &system.variables,
             };

--- a/fiksi/src/constraints/mod.rs
+++ b/fiksi/src/constraints/mod.rs
@@ -18,7 +18,7 @@ pub(crate) mod constraint {
     use crate::{
         System,
         utils::{self},
-        variable_map::IdentityFixedVariableMap,
+        variable_map::IdentityVariableMap,
     };
 
     use super::{Constraint, ConstraintTag};
@@ -93,7 +93,7 @@ pub(crate) mod constraint {
             );
 
             let constraint = &system.constraints[self.id as usize];
-            let variable_map = IdentityFixedVariableMap {
+            let variable_map = IdentityVariableMap {
                 variable_values: &system.variables,
             };
 
@@ -151,7 +151,7 @@ pub(crate) mod constraint {
             let valency = self.tag.valency();
             let constraint = &system.constraints[self.id as usize];
 
-            let variable_map = IdentityFixedVariableMap {
+            let variable_map = IdentityVariableMap {
                 variable_values: &system.variables,
             };
 

--- a/fiksi/src/constraints/mod.rs
+++ b/fiksi/src/constraints/mod.rs
@@ -16,9 +16,9 @@ pub(crate) mod constraint {
     use core::marker::PhantomData;
 
     use crate::{
-        System, VariableMap,
-        collections::{CollectionExt, IndexSet},
+        System,
         utils::{self},
+        variable_map::IdentityFixedVariableMap,
     };
 
     use super::{Constraint, ConstraintTag};
@@ -94,10 +94,8 @@ pub(crate) mod constraint {
 
             let constraint = &system.constraints[self.id as usize];
             // An empty variable map.
-            let variable_map = VariableMap {
-                free_variables: &IndexSet::new(),
+            let variable_map = IdentityFixedVariableMap {
                 variable_values: &system.variables,
-                free_variable_values: &[],
             };
 
             if T::VALENCY > 1 {
@@ -155,10 +153,8 @@ pub(crate) mod constraint {
             let constraint = &system.constraints[self.id as usize];
 
             // An empty variable map.
-            let variable_map = VariableMap {
-                free_variables: &IndexSet::new(),
+            let variable_map = IdentityFixedVariableMap {
                 variable_values: &system.variables,
-                free_variable_values: &[],
             };
 
             if valency > 1 {

--- a/fiksi/src/subsystem.rs
+++ b/fiksi/src/subsystem.rs
@@ -3,7 +3,7 @@
 
 use alloc::vec::Vec;
 
-use crate::{Expression, VariableMap, collections::IndexSet};
+use crate::{Expression, collections::IndexSet, variable_map::IndexSetVariableMap};
 
 pub(crate) struct Subsystem<'s> {
     /// The variable values of the full system.
@@ -90,7 +90,7 @@ impl crate::solve::Problem for Subsystem<'_> {
     }
 
     fn calculate_residuals(&mut self, variables: &[f64], residuals: &mut [f64]) {
-        let variable_map = VariableMap {
+        let variable_map = IndexSetVariableMap {
             free_variables: &self.free_variables,
             variable_values: self.system_variables,
             free_variable_values: variables,
@@ -108,7 +108,7 @@ impl crate::solve::Problem for Subsystem<'_> {
         residuals: &mut [f64],
         jacobian: &mut [f64],
     ) {
-        let variable_map = VariableMap {
+        let variable_map = IndexSetVariableMap {
             free_variables: &self.free_variables,
             variable_values: self.system_variables,
             free_variable_values: variables,

--- a/fiksi/src/variable_map.rs
+++ b/fiksi/src/variable_map.rs
@@ -21,7 +21,7 @@ pub(crate) enum Variable {
 
 /// Map global system variable indices to free or fixed variables.
 ///
-/// Intended for consumption by, e.g., a numeric optimizer. Having this as trait allows
+/// Intended for consumption by, e.g., a numeric optimizer. Having this as a trait allows
 /// specialization, especially for some common cases that are essentially no-ops (see
 /// [`IdentityVariableMap`], which maps indices directly into a slice.
 pub(crate) trait VariableMap {

--- a/fiksi/src/variable_map.rs
+++ b/fiksi/src/variable_map.rs
@@ -19,14 +19,26 @@ pub(crate) enum Variable {
     },
 }
 
+pub(crate) trait VariableMap {
+    /// Get the variable with the global `system_idx` out of the variable map.
+    ///
+    /// The result can be either a free or a fixed variable.
+    ///
+    /// # Panics
+    ///
+    /// This may panic when `system_idx` is out of the map's domain.
+    fn get_value(&self, system_idx: u32) -> Variable;
+}
+
+/// A [`VariableMap`] backed by an [`IndexSet`].
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct VariableMap<'s> {
+pub(crate) struct IndexSetVariableMap<'s> {
     pub(crate) free_variables: &'s IndexSet<u32>,
     pub(crate) variable_values: &'s [f64],
     pub(crate) free_variable_values: &'s [f64],
 }
 
-impl VariableMap<'_> {
+impl VariableMap for IndexSetVariableMap<'_> {
     /// Get the variable with the global `system_idx` out of the variable map.
     ///
     /// It can be either a free or a fixed variable.
@@ -34,7 +46,7 @@ impl VariableMap<'_> {
     /// # Panics
     ///
     /// Panics when `system_idx` is out of bounds.
-    pub(crate) fn get_variable(&self, system_idx: u32) -> Variable {
+    fn get_value(&self, system_idx: u32) -> Variable {
         if let Some(free_idx) = self.free_variables.get_index_of(&system_idx) {
             #[expect(
                 clippy::cast_possible_truncation,
@@ -43,6 +55,40 @@ impl VariableMap<'_> {
             Variable::Free {
                 value: self.free_variable_values[free_idx],
                 idx: free_idx as u32,
+            }
+        } else {
+            Variable::Fixed {
+                value: self.variable_values[system_idx as usize],
+            }
+        }
+    }
+}
+
+/// A [`VariableMap`],  mapping indices directly to a slice.
+///
+/// The const-generic parameter `FREE` is true if and only if the variables are considered free.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct IdentityVariableMap<'s, const FREE: bool> {
+    pub(crate) variable_values: &'s [f64],
+}
+
+pub(crate) type IdentityFreeVariableMap<'s> = IdentityVariableMap<'s, true>;
+
+pub(crate) type IdentityFixedVariableMap<'s> = IdentityVariableMap<'s, true>;
+
+impl<const FREE: bool> VariableMap for IdentityVariableMap<'_, FREE> {
+    /// Get the variable with the global `system_idx` out of the variable map.
+    ///
+    /// The variables are free if and only if the const-generic parameter `FREE` is true.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `system_idx` is out of bounds.
+    fn get_value(&self, system_idx: u32) -> Variable {
+        if FREE {
+            Variable::Free {
+                value: self.variable_values[system_idx as usize],
+                idx: system_idx,
             }
         } else {
             Variable::Fixed {

--- a/fiksi/src/variable_map.rs
+++ b/fiksi/src/variable_map.rs
@@ -19,6 +19,11 @@ pub(crate) enum Variable {
     },
 }
 
+/// Map global system variable indices to free or fixed variables.
+///
+/// Intended for consumption by, e.g., a numeric optimizer. Having this as trait allows
+/// specialization, especially for some common cases that are essentially no-ops (see
+/// [`IdentityVariableMap`], which maps indices directly into a slice.
 pub(crate) trait VariableMap {
     /// Get the variable with the global `system_idx` out of the variable map.
     ///
@@ -31,6 +36,9 @@ pub(crate) trait VariableMap {
 }
 
 /// A [`VariableMap`] backed by an [`IndexSet`].
+///
+/// This maps global system variable indices into either the [`Self::free_variable_values`] slice
+/// or [`Self::variable_values`] slice, containing the free and fixed variables respectively.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct IndexSetVariableMap<'s> {
     pub(crate) free_variables: &'s IndexSet<u32>,

--- a/fiksi/src/variable_map.rs
+++ b/fiksi/src/variable_map.rs
@@ -74,7 +74,7 @@ pub(crate) struct IdentityVariableMap<'s, const FREE: bool> {
 
 pub(crate) type IdentityFreeVariableMap<'s> = IdentityVariableMap<'s, true>;
 
-pub(crate) type IdentityFixedVariableMap<'s> = IdentityVariableMap<'s, true>;
+pub(crate) type IdentityFixedVariableMap<'s> = IdentityVariableMap<'s, false>;
 
 impl<const FREE: bool> VariableMap for IdentityVariableMap<'_, FREE> {
     /// Get the variable with the global `system_idx` out of the variable map.

--- a/fiksi/src/variable_map.rs
+++ b/fiksi/src/variable_map.rs
@@ -72,36 +72,24 @@ impl VariableMap for IndexSetVariableMap<'_> {
     }
 }
 
-/// A [`VariableMap`],  mapping indices directly to a slice.
+/// A [`VariableMap`], mapping indices directly to a slice.
 ///
-/// The const-generic parameter `FREE` is true if and only if the variables are considered free.
+/// All variables are considered free.
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct IdentityVariableMap<'s, const FREE: bool> {
+pub(crate) struct IdentityVariableMap<'s> {
     pub(crate) variable_values: &'s [f64],
 }
 
-pub(crate) type IdentityFreeVariableMap<'s> = IdentityVariableMap<'s, true>;
-
-pub(crate) type IdentityFixedVariableMap<'s> = IdentityVariableMap<'s, false>;
-
-impl<const FREE: bool> VariableMap for IdentityVariableMap<'_, FREE> {
+impl VariableMap for IdentityVariableMap<'_> {
     /// Get the variable with the global `system_idx` out of the variable map.
-    ///
-    /// The variables are free if and only if the const-generic parameter `FREE` is true.
     ///
     /// # Panics
     ///
     /// Panics when `system_idx` is out of bounds.
     fn get_value(&self, system_idx: u32) -> Variable {
-        if FREE {
-            Variable::Free {
-                value: self.variable_values[system_idx as usize],
-                idx: system_idx,
-            }
-        } else {
-            Variable::Fixed {
-                value: self.variable_values[system_idx as usize],
-            }
+        Variable::Free {
+            value: self.variable_values[system_idx as usize],
+            idx: system_idx,
         }
     }
 }


### PR DESCRIPTION
This allows easier specialization, especially for some common ones that are essentially no-ops.