### PR TITLE
Find transitive closure of elements affected during assembly

### DIFF
--- a/fiksi/src/analyze/graph/recursive_assembly.rs
+++ b/fiksi/src/analyze/graph/recursive_assembly.rs
@@ -58,6 +58,7 @@ impl RecombinationPlan {
                 free_elements,
                 on_frontiers: HashMap::new(),
                 owned_elements: HashMap::new(),
+                frontier_elements: HashMap::new(),
             }],
         }
     }
@@ -109,6 +110,9 @@ pub(crate) struct RecombinationStep {
     // element. Once the cluster is merged into a parent cluster, the parent cluster becomes the
     // owner.
     owned_elements: HashMap<ClusterKey, Vec<ElementId>>,
+
+    // Which elements are on each clusters' frontiers.
+    frontier_elements: HashMap<ClusterKey, Vec<ElementId>>,
 }
 
 impl RecombinationStep {
@@ -132,6 +136,10 @@ impl RecombinationStep {
 
     pub(crate) fn owned_elements(&self, cluster: ClusterKey) -> Option<&[ElementId]> {
         self.owned_elements.get(&cluster).map(Vec::as_slice)
+    }
+
+    pub(crate) fn frontier_elements(&self, cluster: ClusterKey) -> Option<&[ElementId]> {
+        self.frontier_elements.get(&cluster).map(Vec::as_slice)
     }
 }
 
@@ -238,6 +246,7 @@ pub(crate) fn decompose<const D: i16>(
                     free_elements: fixes_elements,
                     on_frontiers: on_frontiers.clone(),
                     owned_elements: owned_elements_before,
+                    frontier_elements: frontier_elements.clone(),
                 });
             }
 
@@ -303,6 +312,7 @@ pub(crate) fn decompose<const D: i16>(
                 free_elements: core::mem::take(&mut step_fixes_elements),
                 on_frontiers: on_frontiers.clone(),
                 owned_elements: owned_elements_before,
+                frontier_elements: frontier_elements.clone(),
             });
         }
 

--- a/fiksi/src/assemble/mod.rs
+++ b/fiksi/src/assemble/mod.rs
@@ -276,6 +276,7 @@ impl ClusteredSystem {
 
         self.step_plus_frontier_elements
             .extend_from_slice(step.elements());
+
         {
             // When solving using a recursive assembly plan, elements we're now solving for may
             // occur on one or more existing cluster's frontiers. We need to solve for those


### PR DESCRIPTION
When solving using a recursive assembly plan, elements we're now solving for may occur on one or more existing cluster's frontiers. The previous code correctly solves for those cluster's poses such that all clusters agree on those elements' global positions.

However, the previous code does not take into account that changing one of those clusters' poses may move an element that we're not directly solving for, but which may itself occur on some other cluster's frontier. That cluster will then also have to be moved, etc.

Therefore, we need to solve for the transitive closure of all elements affected.

https://github.com/endoli/fiksi/pull/97 passes once rebased on top of this.