### PR TITLE
Using recursive assembly, solve each constraint exactly once

### DIFF
--- a/fiksi/src/assemble/mod.rs
+++ b/fiksi/src/assemble/mod.rs
@@ -445,9 +445,6 @@ impl solve::Problem for (&'_ mut ClusteredSystem, &'_ System) {
         // Calculate the residuals and gradients of the expressions (of each
         // constraint) in this cluster.
         // TODO: make `VariableMap` a trait, so that we can reuse it here.
-        // TODO: if we solve for coincidence between two or more points that occur
-        // on a child cluster's frontier, we shouldn't need to also solve for
-        // constraints between those points.
         let mut variable_indices = [0; 8];
         let mut variables = [0.; 8];
         let mut gradient = [0.; 8];


### PR DESCRIPTION
In the partial order of clusters, once a constraint has been used to rigidly solve geometry, subsequent clusters can just use the rigid positions of that geometry and don't need to solve that constraint again.

This was already partially in, except for the final, remaining under-rigid subgraph that gets solved at the end.