### PR TITLE
Improve exhaustive dense subgraph finder for recursive assembly

### DIFF
--- a/fiksi/src/analyze/graph/recursive_assembly.rs
+++ b/fiksi/src/analyze/graph/recursive_assembly.rs
@@ -467,18 +467,18 @@ pub(crate) fn decompose<const D: i16>(
     recombination_plan
 }
 
-/// Find an arbitrary, minimum dense subgraph.
+/// Find a minimum dense subgraph, such that no other dense subgraph is smaller than it.
 ///
 /// This searches for a minimum dense subgraph such that
 /// `(elements' degrees of freedom) - (constraints' valencies) < D + 1`. See also "Finding Solvable
 /// Subsets of Constraints Graph" (1997) by C. M. Hoffmann, A. Lomonosov, and M. Sitharam.
 ///
-/// The subgraph is minimum in the sense that it is the smallest subgraph containing no proper
-/// subgraph upholding that condition. Trivial subgraphs of single elements are not considered.
+/// The subgraph is minimum in the sense that there is no smaller subgraph upholding that
+/// condition. Trivial subgraphs of single elements are not considered.
 ///
 /// Returns `None` if no non-trivial dense subgraph exists.
 ///
-/// This does an exhaustive search, which is very slow for every moderately-sized graphs. This
+/// This does an exhaustive search, which is very slow even for moderately-sized graphs. This
 /// should be replaced with a smarter algorithm, as it's not necessary to find the optimum
 /// solution.
 fn dense_bfs<const D: i16>(


### PR DESCRIPTION
The old routine does a depth-first search, which doesn't actually find *minimum* dense subgraphs, which a a breadth-first search does find. Finding small dense subgraphs is important for solving performance. Note both the DFS and the BFS implementations have exponential time-complexity, but BFS will in general lead to constructing more efficient decomposition plans.

https://github.com/endoli/fiksi/pull/97 introduced a polynomial-time *minimal* dense subgraph finder (not *minimum*). Its correctness is harder to check, so I'm thinking to keep the exhaustive search too, for now, mainly for ease of debugging.

In addition to changing to BFS, this now makes use of the sparsity of the graph (normally, most elements only have a few incident edges) to reduce the amount of scanning performed, making this more useful in practice.