### PR TITLE
Replace outdated `doc_auto_cfg`

### DIFF
--- a/fiksi/src/lib.rs
+++ b/fiksi/src/lib.rs
@@ -49,7 +49,7 @@
 // Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 // TODO: remove these two
 #![expect(dead_code, reason = "clean up later")]


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/138907, also see [#linebender > Cargo doc failures in linebender repos](https://xi.zulipchat.com/#narrow/channel/419691-linebender/topic/Cargo.20doc.20failures.20in.20linebender.20repos/with/542106544).