### PR TITLE
Move from `DMatrix` to `Vec`s/slices in numeric analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,15 +99,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,7 +579,6 @@ dependencies = [
  "indexmap",
  "kurbo",
  "libm",
- "nalgebra",
  "solvi",
 ]
 
@@ -1151,16 +1141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,21 +1207,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nalgebra"
-version = "0.33.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d43ddcacf343185dfd6de2ee786d9e8b1c2301622afab66b6c73baf9882abfd"
-dependencies = [
- "approx",
- "matrixmultiply",
- "num-complex",
- "num-rational",
- "num-traits",
- "simba",
- "typenum",
-]
-
-[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1278,45 +1243,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -1809,12 +1735,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
-
-[[package]]
 name = "read-fonts"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1934,15 +1854,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "safe_arch"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2039,19 +1950,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "simba"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide",
-]
 
 [[package]]
 name = "simd-adler32"
@@ -2416,12 +2314,6 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
-
-[[package]]
-name = "typenum"
-version = "1.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -2850,16 +2742,6 @@ dependencies = [
  "log",
  "thiserror 2.0.18",
  "web-sys",
-]
-
-[[package]]
-name = "wide"
-version = "0.7.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
-dependencies = [
- "bytemuck",
- "safe_arch",
 ]
 
 [[package]]

--- a/fiksi/Cargo.toml
+++ b/fiksi/Cargo.toml
@@ -17,16 +17,13 @@ targets = []
 
 [features]
 default = ["std"]
-std = ["kurbo/std", "nalgebra/std", "solvi/std"]
-libm = ["dep:libm", "kurbo/libm", "nalgebra/libm", "solvi/libm"]
+std = ["kurbo/std", "solvi/std"]
+libm = ["dep:libm", "kurbo/libm", "solvi/libm"]
 
 [dependencies]
 hashbrown = { version = "0.15.5", default-features = false, features = ["default-hasher"] }
 indexmap = { version = "2.13.0", default-features = false }
 kurbo = { version = "0.13.0", default-features = false }
-
-# Temporarily included
-nalgebra = { version = "0.33.3", default-features = false, features = ["alloc"] }
 
 solvi.workspace = true
 

--- a/fiksi/src/analyze/numerical/mod.rs
+++ b/fiksi/src/analyze/numerical/mod.rs
@@ -3,8 +3,6 @@
 
 use alloc::{vec, vec::Vec};
 
-use nalgebra::DMatrix;
-
 use crate::{AnyConstraintHandle, System, variable_map::IdentityVariableMap};
 
 const EPSILON: f64 = 1e-8;
@@ -30,12 +28,22 @@ const EPSILON: f64 = 1e-8;
 /// et al.
 ///
 /// In the above, within the context of Fiksi, "rows" are constraints and "columns" are elements.
+///
+/// `matrix` is stored in row-major order, with `nrows` rows and `ncols` columns.
 pub(crate) fn incremental_gauss_jordan_elimination(
-    matrix: &mut DMatrix<f64>,
+    matrix: &mut [f64],
+    nrows: usize,
+    ncols: usize,
     column_indices: &mut [usize],
 ) -> Vec<bool> {
-    let constraints = matrix.nrows();
-    let variables = matrix.ncols();
+    let constraints = nrows;
+    let variables = ncols;
+
+    debug_assert_eq!(
+        matrix.len(),
+        constraints * variables,
+        "`matrix` must contain exactly `nrows * ncols` elements"
+    );
 
     #[cfg(debug_assertions)]
     {
@@ -59,9 +67,9 @@ pub(crate) fn incremental_gauss_jordan_elimination(
             // Only independent rows (i.e., nonzero rows, which increase the rank), take up a pivot
             // column. Hence we can index by rank.
             let column_idx = column_indices[rank];
-            let factor = matrix[(row, column_idx)];
+            let factor = matrix[row * variables + column_idx];
             for col in 0..variables {
-                matrix[(row, col)] -= factor * matrix[(row_idx, col)];
+                matrix[row * variables + col] -= factor * matrix[row_idx * variables + col];
             }
             if constraint_increases_rank[row_idx] {
                 rank += 1;
@@ -73,7 +81,7 @@ pub(crate) fn incremental_gauss_jordan_elimination(
         let mut pivot_found = false;
         for idx in current_col..variables {
             let real_idx = column_indices[idx];
-            if matrix[(row, real_idx)].abs() > EPSILON {
+            if matrix[row * variables + real_idx].abs() > EPSILON {
                 column_indices.swap(current_col, idx);
                 pivot_found = true;
                 break;
@@ -85,18 +93,18 @@ pub(crate) fn incremental_gauss_jordan_elimination(
             continue;
         }
 
-        let factor = matrix[(row, column_indices[current_col])];
+        let factor = matrix[row * variables + column_indices[current_col]];
         for col in 0..variables {
-            matrix[(row, col)] *= 1. / factor;
+            matrix[row * variables + col] *= 1. / factor;
         }
 
         // The above brings the matrix into echelon form. Back-substitute to get *reduced* row
         // echelon form.
         let column_idx = column_indices[current_col];
         for row_idx in 0..row {
-            let factor = matrix[(row_idx, column_idx)];
+            let factor = matrix[row_idx * variables + column_idx];
             for col in 0..variables {
-                matrix[(row_idx, col)] -= factor * matrix[(row, col)];
+                matrix[row_idx * variables + col] -= factor * matrix[row * variables + col];
             }
         }
 
@@ -131,16 +139,13 @@ pub(crate) fn find_overconstraints(system: &System) -> Vec<AnyConstraintHandle> 
         residuals[row] = expression.calculate_residual_and_gradient(variable_map, gradient);
     }
 
-    let mut jacobian_ = nalgebra::DMatrix::zeros(system.expressions.len(), system.variables.len());
-    for i in 0..system.expressions.len() {
-        for j in 0..system.variables.len() {
-            jacobian_[(i, j)] = jacobian[i * system.variables.len() + j];
-        }
-    }
-
-    let mut column_pivots = Vec::from_iter(0..jacobian_.ncols());
-    let independent_expressions =
-        incremental_gauss_jordan_elimination(&mut jacobian_, &mut column_pivots);
+    let mut column_pivots = Vec::from_iter(0..system.variables.len());
+    let independent_expressions = incremental_gauss_jordan_elimination(
+        &mut jacobian,
+        system.expressions.len(),
+        system.variables.len(),
+        &mut column_pivots,
+    );
 
     let mut dependent = vec![];
     for (expression_idx, independent) in independent_expressions.iter().enumerate() {


### PR DESCRIPTION
If this and https://github.com/endoli/fiksi/pull/184 land, `nalgebra` can be removed from the dependencies.