### PR TITLE
Add circle-circle tangency constraints

### DIFF
--- a/fiksi/src/constraints/expressions.rs
+++ b/fiksi/src/constraints/expressions.rs
@@ -37,6 +37,8 @@ pub(crate) enum Expression {
     LineLineParallelism(LineLineParallelism),
     LineLinePerpendicularity(LineLinePerpendicularity),
     LineCircleTangency(LineCircleTangency),
+    CircleCircleExternalTangency(CircleCircleExternalTangency),
+    CircleCircleInternalTangency(CircleCircleInternalTangency),
 }
 
 impl Expression {
@@ -178,6 +180,30 @@ impl Expression {
                 variables[..v.len()].copy_from_slice(&v);
                 &mut variables[..v.len()]
             }
+            Self::CircleCircleExternalTangency(e) => {
+                let v = [
+                    e.circle1_center_idx,
+                    e.circle1_center_idx + 1,
+                    e.circle1_radius_idx,
+                    e.circle2_center_idx,
+                    e.circle2_center_idx + 1,
+                    e.circle2_radius_idx,
+                ];
+                variables[..v.len()].copy_from_slice(&v);
+                &mut variables[..v.len()]
+            }
+            Self::CircleCircleInternalTangency(e) => {
+                let v = [
+                    e.circle1_center_idx,
+                    e.circle1_center_idx + 1,
+                    e.circle1_radius_idx,
+                    e.circle2_center_idx,
+                    e.circle2_center_idx + 1,
+                    e.circle2_radius_idx,
+                ];
+                variables[..v.len()].copy_from_slice(&v);
+                &mut variables[..v.len()]
+            }
         }
     }
 
@@ -271,6 +297,14 @@ impl Expression {
             Self::LineCircleTangency(_) => copy_gradient(
                 gradient,
                 LineCircleTangency::compute_residual_and_gradient_(reslice(variables)),
+            ),
+            Self::CircleCircleExternalTangency(_) => copy_gradient(
+                gradient,
+                CircleCircleExternalTangency::compute_residual_and_gradient_(reslice(variables)),
+            ),
+            Self::CircleCircleInternalTangency(_) => copy_gradient(
+                gradient,
+                CircleCircleInternalTangency::compute_residual_and_gradient_(reslice(variables)),
             ),
         }
     }
@@ -873,6 +907,87 @@ impl LineCircleTangency {
     }
 }
 
+/// Constrain two circles to be externally tangent: they touch from outside.
+#[derive(Clone, Copy)]
+pub(crate) struct CircleCircleExternalTangency {
+    pub(crate) circle1_center_idx: u32,
+    pub(crate) circle1_radius_idx: u32,
+    pub(crate) circle2_center_idx: u32,
+    pub(crate) circle2_radius_idx: u32,
+}
+
+impl From<CircleCircleExternalTangency> for Expression {
+    fn from(expression: CircleCircleExternalTangency) -> Self {
+        Self::CircleCircleExternalTangency(expression)
+    }
+}
+
+impl CircleCircleExternalTangency {
+    // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
+    #[inline(always)]
+    fn compute_residual_and_gradient_(variables: &[f64; 6]) -> (f64, [f64; 6]) {
+        let (residual, gradient) = PointPointDistance::compute_residual_and_gradient_(
+            &[variables[0], variables[1], variables[3], variables[4]],
+            variables[2] + variables[5],
+        );
+
+        (
+            residual,
+            [
+                gradient[0],
+                gradient[1],
+                -1.,
+                gradient[2],
+                gradient[3],
+                -1.,
+            ],
+        )
+    }
+}
+
+/// Constrain two circles to be internally tangent: one contains the other and they touch.
+///
+/// Numerically singular when the circles coincide (`distance(c1, c2) == 0` and `r1 == r2`). The
+/// gradient on the radii is also non-differentiable when `r1 == r2`.
+#[derive(Clone, Copy)]
+pub(crate) struct CircleCircleInternalTangency {
+    pub(crate) circle1_center_idx: u32,
+    pub(crate) circle1_radius_idx: u32,
+    pub(crate) circle2_center_idx: u32,
+    pub(crate) circle2_radius_idx: u32,
+}
+
+impl From<CircleCircleInternalTangency> for Expression {
+    fn from(expression: CircleCircleInternalTangency) -> Self {
+        Self::CircleCircleInternalTangency(expression)
+    }
+}
+
+impl CircleCircleInternalTangency {
+    // See the note about inlining on [`PointPointDistance::compute_residual_and_gradient_`].
+    #[inline(always)]
+    fn compute_residual_and_gradient_(variables: &[f64; 6]) -> (f64, [f64; 6]) {
+        let r_diff = variables[2] - variables[5];
+        let (residual, gradient) = PointPointDistance::compute_residual_and_gradient_(
+            &[variables[0], variables[1], variables[3], variables[4]],
+            r_diff.abs(),
+        );
+
+        let sign = r_diff.signum();
+        (
+            residual,
+            [
+                gradient[0],
+                gradient[1],
+                -sign,
+                gradient[2],
+                gradient[3],
+                sign,
+            ],
+        )
+    }
+}
+
 /// Utility function to reslice an array to a smaller array.
 #[inline(always)]
 fn reslice<const M: usize, const N: usize>(slice: &[f64; M]) -> &[f64; N] {
@@ -956,6 +1071,18 @@ impl Expression {
             }
             Self::LineCircleTangency(_e) => {
                 LineCircleTangency::compute_residual_and_gradient_(reslice(&variable_values)).0
+            }
+            Self::CircleCircleExternalTangency(_e) => {
+                CircleCircleExternalTangency::compute_residual_and_gradient_(reslice(
+                    &variable_values,
+                ))
+                .0
+            }
+            Self::CircleCircleInternalTangency(_e) => {
+                CircleCircleInternalTangency::compute_residual_and_gradient_(reslice(
+                    &variable_values,
+                ))
+                .0
             }
         }
     }
@@ -1083,6 +1210,22 @@ impl Expression {
 
             Self::LineCircleTangency(_e) => map_residual_and_gradient(
                 LineCircleTangency::compute_residual_and_gradient_(reslice(&variable_values)),
+                free_variable_indices,
+                gradient,
+            ),
+
+            Self::CircleCircleExternalTangency(_e) => map_residual_and_gradient(
+                CircleCircleExternalTangency::compute_residual_and_gradient_(reslice(
+                    &variable_values,
+                )),
+                free_variable_indices,
+                gradient,
+            ),
+
+            Self::CircleCircleInternalTangency(_e) => map_residual_and_gradient(
+                CircleCircleInternalTangency::compute_residual_and_gradient_(reslice(
+                    &variable_values,
+                )),
                 free_variable_indices,
                 gradient,
             ),
@@ -1463,6 +1606,53 @@ mod tests {
                     variables.map(|d| (d - 0.5) * 1e-10),
                     delta.map(|d| (d - 0.5) * 1e-14),
                 )
+            },
+        );
+    }
+
+    #[test]
+    fn circle_circle_external_tangency_first_finite_difference() {
+        test_first_finite_difference(
+            CircleCircleExternalTangency::compute_residual_and_gradient_,
+            |variables, delta| {
+                (
+                    variables.map(|d| (d - 0.5) * 1e0),
+                    delta.map(|d| (d - 0.5) * 1e-4),
+                )
+            },
+        );
+        test_first_finite_difference(
+            CircleCircleExternalTangency::compute_residual_and_gradient_,
+            |variables, delta| {
+                (
+                    variables.map(|d| (d - 0.5) * 1e-10),
+                    delta.map(|d| (d - 0.5) * 1e-14),
+                )
+            },
+        );
+    }
+
+    #[test]
+    fn circle_circle_internal_tangency_first_finite_difference() {
+        // The radii (variables[2] and [5]) are biased apart so the finite-difference test
+        // doesn't straddle the `r1 == r2` cusp where the gradient on the radii is
+        // discontinuous.
+        test_first_finite_difference(
+            CircleCircleInternalTangency::compute_residual_and_gradient_,
+            |mut variables, delta| {
+                variables = variables.map(|d| (d - 0.5) * 1e0);
+                variables[2] += 5.;
+                variables[5] += 1.;
+                (variables, delta.map(|d| (d - 0.5) * 1e-4))
+            },
+        );
+        test_first_finite_difference(
+            CircleCircleInternalTangency::compute_residual_and_gradient_,
+            |mut variables, delta| {
+                variables = variables.map(|d| (d - 0.5) * 1e-10);
+                variables[2] += 5e-10;
+                variables[5] += 1e-10;
+                (variables, delta.map(|d| (d - 0.5) * 1e-14))
             },
         );
     }

--- a/fiksi/src/constraints/expressions.rs
+++ b/fiksi/src/constraints/expressions.rs
@@ -933,14 +933,7 @@ impl CircleCircleExternalTangency {
 
         (
             residual,
-            [
-                gradient[0],
-                gradient[1],
-                -1.,
-                gradient[2],
-                gradient[3],
-                -1.,
-            ],
+            [gradient[0], gradient[1], -1., gradient[2], gradient[3], -1.],
         )
     }
 }

--- a/fiksi/src/constraints/mod.rs
+++ b/fiksi/src/constraints/mod.rs
@@ -57,6 +57,12 @@ pub(crate) mod constraint {
 
         /// A handle to a [`LineCircleTangency`](super::LineCircleTangency) constraint.
         LineCircleTangency(ConstraintHandle<super::LineCircleTangency>),
+
+        /// A handle to a [`CircleCircleExternalTangency`](super::CircleCircleExternalTangency) constraint.
+        CircleCircleExternalTangency(ConstraintHandle<super::CircleCircleExternalTangency>),
+
+        /// A handle to a [`CircleCircleInternalTangency`](super::CircleCircleInternalTangency) constraint.
+        CircleCircleInternalTangency(ConstraintHandle<super::CircleCircleInternalTangency>),
     }
 
     /// A handle to a constraint within a [`System`].
@@ -217,6 +223,16 @@ pub(crate) mod constraint {
                 ConstraintTag::LineCircleTangency => TaggedConstraintHandle::LineCircleTangency(
                     ConstraintHandle::from_ids(self.system_id, self.id),
                 ),
+                ConstraintTag::CircleCircleExternalTangency => {
+                    TaggedConstraintHandle::CircleCircleExternalTangency(
+                        ConstraintHandle::from_ids(self.system_id, self.id),
+                    )
+                }
+                ConstraintTag::CircleCircleInternalTangency => {
+                    TaggedConstraintHandle::CircleCircleInternalTangency(
+                        ConstraintHandle::from_ids(self.system_id, self.id),
+                    )
+                }
             }
         }
     }
@@ -891,6 +907,116 @@ impl LineCircleTangency {
     }
 }
 
+/// Constrain two circles to be externally tangent: they touch from outside.
+pub struct CircleCircleExternalTangency {}
+
+impl sealed::ConstraintInner for CircleCircleExternalTangency {
+    fn tag() -> ConstraintTag {
+        ConstraintTag::CircleCircleExternalTangency
+    }
+}
+
+impl CircleCircleExternalTangency {
+    /// Construct a constraint between two circles such that they are externally tangent.
+    pub fn create(
+        system: &mut System,
+        circle1: ElementHandle<elements::Circle>,
+        circle2: ElementHandle<elements::Circle>,
+    ) -> ConstraintHandle<Self> {
+        let &EncodedElement::Circle {
+            center_idx: circle1_center_idx,
+            radius_idx: circle1_radius_idx,
+        } = &system.elements[circle1.id as usize]
+        else {
+            unreachable!()
+        };
+        let &EncodedElement::Circle {
+            center_idx: circle2_center_idx,
+            radius_idx: circle2_radius_idx,
+        } = &system.elements[circle2.id as usize]
+        else {
+            unreachable!()
+        };
+
+        system.graph.add_constraint(
+            1,
+            IncidentElements::from_array([
+                system.variable_to_primitive[circle1_center_idx as usize],
+                system.variable_to_primitive[circle1_radius_idx as usize],
+                system.variable_to_primitive[circle2_center_idx as usize],
+                system.variable_to_primitive[circle2_radius_idx as usize],
+            ]),
+        );
+        system.add_constraint(
+            ConstraintTag::CircleCircleExternalTangency,
+            [expressions::CircleCircleExternalTangency {
+                circle1_center_idx,
+                circle1_radius_idx,
+                circle2_center_idx,
+                circle2_radius_idx,
+            }
+            .into()],
+        )
+    }
+}
+
+/// Constrain two circles to be internally tangent: one circle contains the other and they
+/// touch.
+///
+/// The constraint is symmetric in `circle1` and `circle2`: either may be the containing
+/// circle, and a solve may swap their roles.
+pub struct CircleCircleInternalTangency {}
+
+impl sealed::ConstraintInner for CircleCircleInternalTangency {
+    fn tag() -> ConstraintTag {
+        ConstraintTag::CircleCircleInternalTangency
+    }
+}
+
+impl CircleCircleInternalTangency {
+    /// Construct a constraint between two circles such that they are internally tangent.
+    pub fn create(
+        system: &mut System,
+        circle1: ElementHandle<elements::Circle>,
+        circle2: ElementHandle<elements::Circle>,
+    ) -> ConstraintHandle<Self> {
+        let &EncodedElement::Circle {
+            center_idx: circle1_center_idx,
+            radius_idx: circle1_radius_idx,
+        } = &system.elements[circle1.id as usize]
+        else {
+            unreachable!()
+        };
+        let &EncodedElement::Circle {
+            center_idx: circle2_center_idx,
+            radius_idx: circle2_radius_idx,
+        } = &system.elements[circle2.id as usize]
+        else {
+            unreachable!()
+        };
+
+        system.graph.add_constraint(
+            1,
+            IncidentElements::from_array([
+                system.variable_to_primitive[circle1_center_idx as usize],
+                system.variable_to_primitive[circle1_radius_idx as usize],
+                system.variable_to_primitive[circle2_center_idx as usize],
+                system.variable_to_primitive[circle2_radius_idx as usize],
+            ]),
+        );
+        system.add_constraint(
+            ConstraintTag::CircleCircleInternalTangency,
+            [expressions::CircleCircleInternalTangency {
+                circle1_center_idx,
+                circle1_radius_idx,
+                circle2_center_idx,
+                circle2_radius_idx,
+            }
+            .into()],
+        )
+    }
+}
+
 /// The actual type of the constraint.
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum ConstraintTag {
@@ -905,6 +1031,8 @@ pub(crate) enum ConstraintTag {
     LineLineParallelism,
     LineLinePerpendicularity,
     LineCircleTangency,
+    CircleCircleExternalTangency,
+    CircleCircleInternalTangency,
 }
 
 impl ConstraintTag {
@@ -921,6 +1049,8 @@ impl ConstraintTag {
             Self::LineLineParallelism => LineLineParallelism::VALENCY,
             Self::LineLinePerpendicularity => LineLinePerpendicularity::VALENCY,
             Self::LineCircleTangency => LineCircleTangency::VALENCY,
+            Self::CircleCircleExternalTangency => CircleCircleExternalTangency::VALENCY,
+            Self::CircleCircleInternalTangency => CircleCircleInternalTangency::VALENCY,
         }
     }
 }
@@ -986,6 +1116,14 @@ impl Constraint for LineLinePerpendicularity {
 }
 
 impl Constraint for LineCircleTangency {
+    const VALENCY: u8 = 1;
+}
+
+impl Constraint for CircleCircleExternalTangency {
+    const VALENCY: u8 = 1;
+}
+
+impl Constraint for CircleCircleInternalTangency {
     const VALENCY: u8 = 1;
 }
 

--- a/fiksi/src/manual/mod.rs
+++ b/fiksi/src/manual/mod.rs
@@ -72,6 +72,8 @@
 //! | [Line-line angle][lla]           | 2 (line, line)          | Angle      | 1 |
 //! | [Line-line parallelism][llp]     | 2 (line, line)          |            | 1 |
 //! | [Line-circle tangency][lct]      | 2 (line, circle)        |            | 1 |
+//! | [Circle-circle external tangency][ccet] | 2 (circle, circle) |            | 1 |
+//! | [Circle-circle internal tangency][ccit] | 2 (circle, circle) |            | 1 |
 //!
 //! [ppc]: `constraints::PointPointCoincidence`
 //! [ppd]: `constraints::PointPointDistance`
@@ -82,6 +84,8 @@
 //! [lla]: `constraints::LineLineAngle`
 //! [llp]: `constraints::LineLineParallelism`
 //! [lct]: `constraints::LineCircleTangency`
+//! [ccet]: `constraints::CircleCircleExternalTangency`
+//! [ccit]: `constraints::CircleCircleInternalTangency`
 //!
 //! ## Decomposition
 //!

--- a/fiksi/src/tests/basic.rs
+++ b/fiksi/src/tests/basic.rs
@@ -174,8 +174,7 @@ fn circle_circle_external_tangency() {
 
     s.solve(crate::SolvingOptions::default());
 
-    let rms_residuals =
-        root_mean_squares([t1.calculate_residual(&s), t2.calculate_residual(&s)]);
+    let rms_residuals = root_mean_squares([t1.calculate_residual(&s), t2.calculate_residual(&s)]);
     assert!(
         rms_residuals < RESIDUAL_THRESHOLD,
         "The system was not solved (root mean square residuals: {rms_residuals})"

--- a/fiksi/src/tests/basic.rs
+++ b/fiksi/src/tests/basic.rs
@@ -148,6 +148,67 @@ fn triangle_inscribed_circle() {
     );
 }
 
+/// Two free circles externally tangent to a fixed circle.
+#[test]
+fn circle_circle_external_tangency() {
+    let mut s = System::new();
+
+    let p_anchor = elements::Point::create(&mut s, 0., 0.);
+    let r_anchor = elements::Length::create(&mut s, 1.);
+    let anchor = elements::Circle::create(&mut s, p_anchor, r_anchor);
+    anchor.fix(&mut s);
+
+    let p1 = elements::Point::create(&mut s, 2.5, 0.1);
+    let r1 = elements::Length::create(&mut s, 0.7);
+    let c1 = elements::Circle::create(&mut s, p1, r1);
+
+    let p2 = elements::Point::create(&mut s, -2., 0.5);
+    let r2 = elements::Length::create(&mut s, 0.4);
+    let c2 = elements::Circle::create(&mut s, p2, r2);
+
+    constraints::PointPointDistance::create(&mut s, p_anchor, p1, 1.7);
+    constraints::PointPointDistance::create(&mut s, p_anchor, p2, 1.4);
+
+    let t1 = constraints::CircleCircleExternalTangency::create(&mut s, anchor, c1);
+    let t2 = constraints::CircleCircleExternalTangency::create(&mut s, anchor, c2);
+
+    s.solve(crate::SolvingOptions::default());
+
+    let rms_residuals =
+        root_mean_squares([t1.calculate_residual(&s), t2.calculate_residual(&s)]);
+    assert!(
+        rms_residuals < RESIDUAL_THRESHOLD,
+        "The system was not solved (root mean square residuals: {rms_residuals})"
+    );
+}
+
+/// A small circle internally tangent to a fixed larger circle.
+#[test]
+fn circle_circle_internal_tangency() {
+    let mut s = System::new();
+
+    let p_outer = elements::Point::create(&mut s, 0., 0.);
+    let r_outer = elements::Length::create(&mut s, 2.);
+    let outer = elements::Circle::create(&mut s, p_outer, r_outer);
+    outer.fix(&mut s);
+
+    let p_inner = elements::Point::create(&mut s, 0.3, 0.1);
+    let r_inner = elements::Length::create(&mut s, 0.5);
+    let inner = elements::Circle::create(&mut s, p_inner, r_inner);
+
+    constraints::PointPointDistance::create(&mut s, p_outer, p_inner, 1.5);
+
+    let tangency = constraints::CircleCircleInternalTangency::create(&mut s, outer, inner);
+
+    s.solve(crate::SolvingOptions::default());
+
+    let residual = tangency.calculate_residual(&s);
+    assert!(
+        residual.abs() < RESIDUAL_THRESHOLD,
+        "The system was not solved (residual: {residual})"
+    );
+}
+
 #[test]
 fn two_connected_components() {
     let mut s = System::new();


### PR DESCRIPTION
This adds two types of circle tangency constraints: an externally tangent one, where the circles touch from outside, and an internally tangent one, where one circle is contained inside the other and they touch.

Note that in the internally tangent there is not a concept of one circle being the interior one; the constraint itself is symmetric.